### PR TITLE
Make repl arg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     setup_requires=['setuptools>=17.1'],
-    version="0.0.7"
+    version="0.0.8"
 )

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -51,14 +51,14 @@ class TestSolrCloudTasks(unittest.TestCase):
     def test_create_sc_collection(self, mocker):
         """Test create_sc_collection operator instance contains expected config values."""
         dag = DAG(dag_id='test_create_sc_collection', start_date=DEFAULT_DATE)
-        operator = create_sc_collection(dag, 'SOLRCLOUD', 'test-collection', 'test-configset')
+        operator = create_sc_collection(dag, 'SOLRCLOUD', 'test-collection', '2', 'test-configset')
         task_instance = TaskInstance(task=operator, execution_date=DEFAULT_DATE)
 
         self.assertEqual("SOLRCLOUD", operator.http_conn_id)
         self.assertEqual("CREATE", operator.data['action'])
         self.assertEqual("test-collection", operator.data['name'])
         self.assertEqual("1", operator.data['numShards'])
-        self.assertEqual("3", operator.data['replicationFactor'])
+        self.assertEqual("2", operator.data['replicationFactor'])
         self.assertEqual("test-configset", operator.data['collection.configName'])
         self.assertEqual("create_collection", task_instance.task_id)
 

--- a/tulflow/tasks.py
+++ b/tulflow/tasks.py
@@ -43,7 +43,7 @@ def slackpostonsuccess(dag, message='Oh, happy day!'):
     return slack_post
 
 
-def create_sc_collection(dag, sc_conn_id, sc_coll_name, sc_configset_name):
+def create_sc_collection(dag, sc_conn_id, sc_coll_name, sc_coll_repl, sc_configset_name):
     """Creates a new SolrCloud Collection."""
     task_instance = SimpleHttpOperator(
         task_id="create_collection",
@@ -54,7 +54,7 @@ def create_sc_collection(dag, sc_conn_id, sc_coll_name, sc_configset_name):
             "action": "CREATE",
             "name": sc_coll_name,
             "numShards": "1",
-            "replicationFactor": "3",
+            "replicationFactor": sc_coll_repl,
             "maxShardsPerNode": "1",
             "collection.configName": sc_configset_name
         },


### PR DESCRIPTION
Making replicationFactor an argument to pass in, so code calling the tasks solrcloud collection creation can set the replication factor at that time. Breaks client code by adding new arg.