### PR TITLE
Define tuflow.tasks.get_solr_url

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -7,7 +7,7 @@ from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Connection, DAG, TaskInstance
 from airflow.utils import timezone
-from tulflow.tasks import execute_slackpostonfail, slackpostonsuccess, create_sc_collection, swap_sc_alias
+from tulflow.tasks import execute_slackpostonfail, slackpostonsuccess, create_sc_collection, swap_sc_alias, get_solr_url
 
 DEFAULT_DATE = timezone.datetime(2019, 8, 16)
 
@@ -81,3 +81,21 @@ class TestSolrCloudTasks(unittest.TestCase):
         self.assertEqual("my-alias", operator.data['name'])
         self.assertEqual(["new-collection"], operator.data['collections'])
         self.assertEqual("solr_alias_swap", task_instance.task_id)
+
+class TestTasksGetSolrUrl(unittest.TestCase):
+    """Tests for tasks.get_solr_url function."""
+
+    def test_get_solr_url_without_http_in_host(self):
+        conn = Connection(host="example.com", port="8983")
+        core = "foo"
+        self.assertEqual(get_solr_url(conn, core), "http://example.com:8983/solr/foo")
+
+    def test_get_solr_url_with_http_in_host(self):
+        conn = Connection(host="https://example.com", port="8983")
+        core = "foo"
+        self.assertEqual(get_solr_url(conn, core), "https://example.com:8983/solr/foo")
+
+    def test_get_solr_url_without_port(self):
+        conn = Connection(host="https://example.com")
+        core = "foo"
+        self.assertEqual(get_solr_url(conn, core), "https://example.com/solr/foo")

--- a/tulflow/tasks.py
+++ b/tulflow/tasks.py
@@ -1,4 +1,5 @@
 """Generic Airflow Tasks Functions, Abstracted for Reuse."""
+import re
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.operators.http_operator import SimpleHttpOperator
@@ -84,3 +85,26 @@ def swap_sc_alias(dag, sc_conn_id, sc_coll_name, sc_configset_name):
     )
 
     return task_instance
+
+def get_solr_url(conn, core):
+    """  Generates a solr url from  passed in connection and core.
+
+    Parameters:
+        conn (airflow.models.connection): Connection object representing solr we index to.
+        core (str)  The solr collection or configuration  to use.
+
+    Returns:
+        solr_url (str): A solr URL.
+
+    """
+    solr_url = conn.host
+
+    if not re.match("^http", solr_url):
+        solr_url = 'http://' + solr_url
+
+    if conn.port:
+        solr_url += ':' + str(conn.port)
+
+    solr_url += '/solr/' + core
+
+    return solr_url


### PR DESCRIPTION
Used to get the solr url in dags in a way that allows us to specify or
not specify https in the conn.host.