### PR TITLE
OAI additions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     setup_requires=['setuptools>=17.1'],
-    version="0.3.0"
+    version="0.3.1"
 )

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,7 +1,7 @@
 """Tests suite for tulflow harvest (Functions for harvesting OAI in Airflow Tasks)."""
 from datetime import datetime
 import hashlib
-import os
+import logging
 import unittest
 from unittest import mock
 from unittest.mock import patch
@@ -80,6 +80,65 @@ animals = """
 </OAI-PMH>
 """
 
+marc = """
+<OAI-PMH xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <responseDate>2019-11-08T13:43:00Z</responseDate>
+    <request verb="ListRecords" metadataPrefix="marc21" set="blacklight">https://na02.alma.exlibrisgroup.com/view/oai/01TULI_INST/request</request>
+    <ListRecords>
+        <record>
+            <header>
+                <identifier>oai:alma.01TULI_INST:991000000269703811</identifier>
+                <datestamp>2019-07-15T15:17:33Z</datestamp>
+                <setSpec>blacklight</setSpec>
+                <setSpec>blacklight_qa</setSpec>
+                <setSpec>rapid_print_books</setSpec>
+            </header>
+            <metadata>
+                <record xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd">
+                    <leader>01407nam a2200445 4500</leader>
+                    <controlfield tag="005">20190715090942.0</controlfield>
+                    <controlfield tag="008">690326s1969 nju b 000 0 eng </controlfield>
+                    <controlfield tag="001">991000000269703811</controlfield>
+                    <datafield tag="010" ind1=" " ind2=" ">
+                        <subfield code="a">68020157</subfield>
+                    </datafield>
+                    <datafield tag="035" ind1=" " ind2=" ">
+                        <subfield code="a">(PPT)b10000276-01tuli_inst</subfield>
+                    </datafield>
+                    <datafield tag="040" ind1=" " ind2=" ">
+                        <subfield code="a">DLC</subfield>
+                        <subfield code="b">eng</subfield>
+                        <subfield code="c">DLC</subfield>
+                        <subfield code="d">PPT</subfield>
+                    </datafield>
+                    <datafield tag="090" ind1=" " ind2=" ">
+                        <subfield code="a">HM131.E85</subfield>
+                    </datafield>
+                    <datafield tag="100" ind1="1" ind2=" ">
+                        <subfield code="a">Etzioni, Amitai.</subfield>
+                        <subfield code="0">http://id.loc.gov/authorities/names/n79089329</subfield>
+                    </datafield>
+                    <datafield tag="245" ind1="1" ind2="0">
+                        <subfield code="a">Readings on modern organizations.</subfield>
+                    </datafield>
+                </record>
+            </metadata>
+        </record>
+        <record>
+            <header status="deleted">
+                <identifier>oai:alma.01TULI_INST:991000000939703811</identifier>
+                <datestamp>2018-04-02T21:02:12Z</datestamp>
+                <setSpec>blacklight</setSpec>
+            </header>
+        </record>
+    </ListRecords>
+</OAI-PMH>
+"""
+
+lookup = """child_id,parent_id,parent_xml
+991000000269703811,9910367273103811,"<datafield>test</datafield>||<ns0:datafield>9910367273103811</ns0:datafield>"
+"""
+
 
 class TestDagS3Interaction(unittest.TestCase):
     """Test Class for S3 Post Wrapper."""
@@ -96,19 +155,21 @@ class TestDagS3Interaction(unittest.TestCase):
         self.assertEqual(prefix, "{}/{}".format(self.dag_id, timestamp))
 
 
-    @patch.object(S3Hook, 'load_string')
+    @mock.patch('tulflow.process.generate_s3_object')
     def test_write_push_string_to_s3(self, mock):
         """Test Writing String to S3 using our Function."""
         string = "<fooooooooo>"
         prefix = "this/thing/here"
-        bucket = "my-bucket"
+        kwargs = {}
+        kwargs["access_id"] = "puppies"
+        kwargs["access_secret"] = "kittens"
+        kwargs["bucket_name"] = "my-bucket"
         our_hash = hashlib.md5(string.encode('utf-8')).hexdigest()
         key = "{}/{}".format(prefix, our_hash)
-        s3_conn = SimpleNamespace(conn_id="1")
 
 
-        dag_write_string_to_s3(string=string, prefix=prefix, s3_conn=s3_conn, bucket_name=bucket)
-        mock.assert_called_once_with(string, key, bucket_name=bucket)
+        dag_write_string_to_s3(string=string, prefix=prefix, **kwargs)
+        mock.assert_called_once_with(string, "my-bucket", key, "puppies", "kittens")
 
 
 class TestOAIHarvestInteraction(unittest.TestCase):
@@ -141,9 +202,8 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         self.assertIn(b"<setSpec>dpla_test</setSpec>", xml_output)
         self.assertIn(b"<dcterms:title>lizards</dcterms:title>", xml_output)
 
-
     @httpretty.activate
-    def test_process_xml(self, **kwargs):
+    def test_process_xml_dpla(self, **kwargs):
         """Test Calling handling XML Element to String."""
         httpretty.register_uri(
             httpretty.GET,
@@ -159,10 +219,53 @@ class TestOAIHarvestInteraction(unittest.TestCase):
             'until': None
         }
 
-        response = harvest_oai(**kwargs)
-        count = process_xml(response, write_log, **kwargs)
-        self.assertEqual(count, 2)
+        with self.assertLogs() as log:
+            response = harvest_oai(**kwargs)
+            process_xml(response, write_log, "test-dir", **kwargs)
+        self.assertIn("INFO:root:OAI Records Harvested & Processed: 2", log.output)
 
+
+    @httpretty.activate
+    def test_process_xml_alma(self, **kwargs):
+        """Test Calling handling XML Element to String with Deletes."""
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://127.0.0.1/alma/oai",
+            body=marc
+        )
+
+        kwargs['oai_endpoint'] = "http://127.0.0.1/alma/oai"
+        kwargs['harvest_params'] = {
+            'metadataPrefix': 'marc21',
+            'set': 'blacklight',
+            'from': 2019-10-21,
+            'until': None
+        }
+
+        with self.assertLogs() as log:
+            response = harvest_oai(**kwargs)
+            process_xml(response, write_log, "test-dir", **kwargs)
+        self.assertIn("INFO:root:OAI Records Harvested & Processed: 1", log.output)
+        self.assertIn("INFO:root:OAI Records Harvest & Marked for Deletion: 0", log.output)
+
+    @mock_s3
+    def test_perform_xml_lookup(self, **kwargs):
+        """Test Calling handling XML Element to String with Deletes."""
+        kwargs["access_key"] = "cats"
+        kwargs["access_secret"] = "dogs"
+        kwargs["bucket"] = "alma-test"
+        kwargs["lookup_key"] = "sc_catalog_pipeline/0000-00-00/lookup.tsv"
+
+        conn = boto3.client(
+            "s3",
+            aws_access_key_id=kwargs.get("access_key"),
+            aws_secret_access_key=kwargs.get("access_secret")
+        )
+        conn.create_bucket(Bucket=kwargs.get("bucket"))
+        conn.put_object(Bucket=kwargs.get("bucket"), Key=kwargs.get("lookup_key"), Body=lookup)
+        marc_xml = etree.fromstring(marc)
+        resp_xml = perform_xml_lookup(marc_xml, **kwargs)
+        self.assertTrue(resp_xml, "")
 
     @mock.patch('tulflow.harvest.harvest_oai')
     @mock.patch('tulflow.harvest.dag_s3_prefix')
@@ -171,6 +274,7 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         """Test oai_to_s3 wraps harvest_oai function."""
         dag = DAG(dag_id='test_slacksuccess', start_date=DEFAULT_DATE)
         kwargs['oai_endpoint'] = "http://test/combine/oai"
+        kwargs['metadataPrefix'] = "blergh"
         kwargs['set'] = "set"
         kwargs['from'] = "from"
         kwargs['until'] = "until"

--- a/tulflow/tasks.py
+++ b/tulflow/tasks.py
@@ -10,37 +10,37 @@ PP = pprint.PrettyPrinter(indent=4)
 
 def execute_slackpostonfail(context, message=None):
     """Task Method to Post Failed DAG or Task Completion on Slack."""
-    conn = BaseHook.get_connection('AIRFLOW_CONN_SLACK_WEBHOOK')
-    task_instance = context.get('task_instance')
+    conn = BaseHook.get_connection("AIRFLOW_CONN_SLACK_WEBHOOK")
+    task_instance = context.get("task_instance")
     log_url = task_instance.log_url
     task_id = task_instance.task_id
     dag_id = task_instance.dag_id
-    task_date = context.get('execution_date')
+    task_date = context.get("execution_date")
     if not message:
         message = "Task failed: {} {} {} {}".format(dag_id, task_id, task_date, log_url)
 
     slack_post = SlackWebhookOperator(
-        task_id='slackpostonfail',
-        http_conn_id='AIRFLOW_CONN_SLACK_WEBHOOK',
+        task_id="slackpostonfail",
+        http_conn_id="AIRFLOW_CONN_SLACK_WEBHOOK",
         webhook_token=conn.password,
         message=":poop: " + message,
-        username='airflow',
-        dag=context.get('dag')
+        username="airflow",
+        dag=context.get("dag")
         )
 
     return slack_post.execute(context=context)
 
 
-def slackpostonsuccess(dag, message='Oh, happy day!'):
+def slackpostonsuccess(dag, message="Oh, happy day!"):
     """Task Method to Post Successful DAG or Task Completion on Slack."""
-    conn = BaseHook.get_connection('AIRFLOW_CONN_SLACK_WEBHOOK')
+    conn = BaseHook.get_connection("AIRFLOW_CONN_SLACK_WEBHOOK")
 
     slack_post = SlackWebhookOperator(
         task_id="slackpostonsuccess",
-        http_conn_id='AIRFLOW_CONN_SLACK_WEBHOOK',
+        http_conn_id="AIRFLOW_CONN_SLACK_WEBHOOK",
         webhook_token=conn.password,
-        message=':partygritty: ' + message,
-        username='airflow',
+        message=":partygritty: " + message,
+        username="airflow",
         trigger_rule="all_success",
         dag=dag)
 
@@ -51,7 +51,7 @@ def create_sc_collection(dag, sc_conn_id, sc_coll_name, sc_coll_repl, sc_configs
     """Creates a new SolrCloud Collection."""
     task_instance = SimpleHttpOperator(
         task_id="create_collection",
-        method='GET',
+        method="GET",
         http_conn_id=sc_conn_id,
         endpoint="solr/admin/collections",
         data={
@@ -74,7 +74,7 @@ def swap_sc_alias(dag, sc_conn_id, sc_coll_name, sc_configset_name):
     """Create or point an existing SolrCloud Alias to an existing SolrCloud Collection."""
     task_instance = SimpleHttpOperator(
         task_id="solr_alias_swap",
-        method='GET',
+        method="GET",
         http_conn_id=sc_conn_id,
         endpoint="solr/admin/collections",
         data={
@@ -88,6 +88,7 @@ def swap_sc_alias(dag, sc_conn_id, sc_coll_name, sc_configset_name):
     )
 
     return task_instance
+
 
 def get_solr_url(conn, core):
     """  Generates a solr url from  passed in connection and core.
@@ -103,12 +104,12 @@ def get_solr_url(conn, core):
     solr_url = conn.host
 
     if not re.match("^http", solr_url):
-        solr_url = 'http://' + solr_url
+        solr_url = "http://" + solr_url
 
     if conn.port:
-        solr_url += ':' + str(conn.port)
+        solr_url += ":" + str(conn.port)
 
-    solr_url += '/solr/' + core
+    solr_url += "/solr/" + core
 
     return solr_url
 

--- a/tulflow/tasks.py
+++ b/tulflow/tasks.py
@@ -1,8 +1,11 @@
 """Generic Airflow Tasks Functions, Abstracted for Reuse."""
 import re
+import pprint
 from airflow.hooks.base_hook import BaseHook
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.operators.http_operator import SimpleHttpOperator
+
+PP = pprint.PrettyPrinter(indent=4)
 
 
 def execute_slackpostonfail(context, message=None):
@@ -108,3 +111,12 @@ def get_solr_url(conn, core):
     solr_url += '/solr/' + core
 
     return solr_url
+
+def conditionally_trigger(context, dag_run_obj):
+    """This function decides whether or not to Trigger the remote DAG"""
+    c_p = context['params']['condition_param']
+    print("Controller DAG : conditionally_trigger = {}".format(c_p))
+    if context['params']['condition_param']:
+        dag_run_obj.payload = {'message': context['params']['message']}
+        PP.pprint(dag_run_obj.payload)
+        return dag_run_obj


### PR DESCRIPTION
What this PR does:
- adds support for filtering out deleted records in OAI to S3 harvest functions
- adds generic lookup CSV & inject into XML upon identifier match function (used for boundwiths)
- adds ability to write out deleted & updated files to s3 in separate prefixes
- adds more tests