### PR TITLE
Add schematron

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     setup_requires=['setuptools>=17.1'],
-    version="0.3.2"
+    version="0.3.3"
 )

--- a/tests/fixtures/sch-oai-empty.xml
+++ b/tests/fixtures/sch-oai-empty.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:edm="http://www.europeana.eu/schemas/edm/"
+   xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/"
+   xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+   xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+</metadata>

--- a/tests/fixtures/sch-oai-invalid.xml
+++ b/tests/fixtures/sch-oai-invalid.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:edm="http://www.europeana.eu/schemas/edm/"
+   xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/"
+   xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+   xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:creator>Owens, William</dcterms:creator>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:description>Dignity Philadelphia mass for gay and lesbian catholics at the Civic
+         Center.</dcterms:description>
+      <dcterms:spatial>Civic Center (Philadelphia, Pa.);</dcterms:spatial>
+      <dcterms:date>1976-08-03</dcterms:date>
+      <dcterms:subject>Gay rights</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:type>Image</dcterms:type>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>invalid-missingtitle</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/1</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Pearl Harbor</dcterms:title>
+      <dcterms:creator>KIDSNET (Organization)</dcterms:creator>
+      <dcterms:description>KIDSNET educational brochure about Pearl Harbor</dcterms:description>
+      <dcterms:description>Test language code.</dcterms:description>
+      <dcterms:date>1991</dcterms:date>
+      <dcterms:subject>Children's television programs--United States</dcterms:subject>
+      <dcterms:language>eng</dcterms:language>
+      <dcterms:type>Text</dcterms:type>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>invalid-missingrights</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/6</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Letter of 1866 April 30</dcterms:title>
+      <dcterms:creator>Still, William, 1821-1902</dcterms:creator>
+      <dcterms:description>William Still writes a letter to his daughter, Caroline, who is away at
+         school, in response to her letter telling him of her difficulty with her mathematical
+         studies and suggesting the whole family move to Oberlin. Still tells her she should learn
+         the rules of Math as he wants to set her up in a shop when she graduates, and he will stay
+         in Philadelphia as he has just bought two properties and has other business
+         ventures.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test coverage spatial, language.</dcterms:description>
+      <dcterms:spatial>Lombard Street (Philadelphia, Pa.); Oberlin (Ohio);</dcterms:spatial>
+      <dcterms:spatial>Lombard Street (Philadelphia, Pa.); Oberlin (Ohio);</dcterms:spatial>
+      <dcterms:date>1866-04-30</dcterms:date>
+      <dcterms:subject>African American fathers</dcterms:subject>
+      <dcterms:subject> Fathers and daughters</dcterms:subject>
+      <dcterms:subject> African American businesspeople</dcterms:subject>
+      <dcterms:subject> African American abolitionists</dcterms:subject>
+      <dcterms:subject>Anderson, Caroline Still, 1848-1911 [recipient]</dcterms:subject>
+      <dcterms:subject> Cassey, Joseph, 1789-1848</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:language>English</dcterms:language>
+      <dcterms:type>Text</dcterms:type>
+      <dcterms:rights>Public domain</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-missingitemurl</dcterms:identifier>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Ella Fitzgerald</dcterms:title>
+      <dcterms:creator>Mosley, John W.</dcterms:creator>
+      <dcterms:description>Ella Fitzgerald (1917-1996), also known as “Lady Ella” and the “First
+         Lady of Song.”, as early as the age of 17 performed songs by Connee Boswell to win “Amateur
+         Night” at Harlem New York’s Apollo Theatre. After four years as a singer in Chick Webb’s
+         Orchestra, Fitzgerald in 1939 took on the leadership of the band, and it was renamed Ella
+         and her Famous Orchestra. The band recorded together until 1942 when Fitzgerald began her
+         solo career. For her jazz vocals she won 13 Grammy awards including the coveted Best Female
+         Vocalist category for three years in a row.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Testing circa date</dcterms:description>
+      <dcterms:subject>African American jazz musicians</dcterms:subject>
+      <dcterms:subject> Fitzgerald, Ella</dcterms:subject>
+      <dcterms:format>banana;peach</dcterms:format>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, the Charles L. Blockson Afro-American Collection (blockson@temple.edu;
+         215-204-6632)</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-missingprovider</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/12</edm:isShownAt>
+      <dcterms:isPartOf>John W. Mosley Photograph Collection</dcterms:isPartOf>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Wise Acres 1914 March</dcterms:title>
+      <dcterms:description>Yearbook of the Pennsylvania School of Horticulture for Women Vol. I No.
+         1</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test local rights and DPLA rights.</dcterms:description>
+      <dcterms:date>1914-03</dcterms:date>
+      <dcterms:subject>Temple University--School of Environmental
+         Design--Students--Periodicals</dcterms:subject>
+      <dcterms:subject> Temple University--School of Environmental
+         Design--Students--Yearbooks</dcterms:subject>
+      <dcterms:subject>Horticulture Students--Periodicals</dcterms:subject>
+      <dcterms:type>Text</dcterms:type>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, Special Collection Research Center, scrc@temple.edu,
+         215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-malformeditemurl</dcterms:identifier>
+      <edm:isShownAt>id/33</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+</metadata>

--- a/tests/fixtures/sch-oai-mix.xml
+++ b/tests/fixtures/sch-oai-mix.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:edm="http://www.europeana.eu/schemas/edm/"
+   xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/"
+   xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+   xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+   <oai_dc:dc>
+      <dcterms:title>Celebration at Independence Hall</dcterms:title>
+      <dcterms:creator>pdcp_noharvest</dcterms:creator>
+      <dcterms:creator>Philadelphia Evening Bulletin</dcterms:creator>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower of
+         Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+         system immediately in front of Independence Hall entrance. Note dirigible in left upper
+         quadrant of photo.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+         Pa.)</dcterms:spatial>
+      <dcterms:date>1924</dcterms:date>
+      <dcterms:subject>Statues</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>This material is made available for private study, scholarship, and research
+         use. For access to the original, contact: Temple University Libraries. Special Collections
+         Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>valid</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:creator>Owens, William</dcterms:creator>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:description>Dignity Philadelphia mass for gay and lesbian catholics at the Civic
+         Center.</dcterms:description>
+      <dcterms:spatial>Civic Center (Philadelphia, Pa.);</dcterms:spatial>
+      <dcterms:date>1976-08-03</dcterms:date>
+      <dcterms:subject>Gay rights</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:type>Image</dcterms:type>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>invalid-missingtitle</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/1</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Pearl Harbor</dcterms:title>
+      <dcterms:creator>KIDSNET (Organization)</dcterms:creator>
+      <dcterms:description>KIDSNET educational brochure about Pearl Harbor</dcterms:description>
+      <dcterms:description>Test language code.</dcterms:description>
+      <dcterms:date>1991</dcterms:date>
+      <dcterms:subject>Children's television programs--United States</dcterms:subject>
+      <dcterms:language>eng</dcterms:language>
+      <dcterms:type>Text</dcterms:type>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>invalid-missingrights</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/6</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Letter of 1866 April 30</dcterms:title>
+      <dcterms:creator>Still, William, 1821-1902</dcterms:creator>
+      <dcterms:description>William Still writes a letter to his daughter, Caroline, who is away at
+         school, in response to her letter telling him of her difficulty with her mathematical
+         studies and suggesting the whole family move to Oberlin. Still tells her she should learn
+         the rules of Math as he wants to set her up in a shop when she graduates, and he will stay
+         in Philadelphia as he has just bought two properties and has other business
+         ventures.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test coverage spatial, language.</dcterms:description>
+      <dcterms:spatial>Lombard Street (Philadelphia, Pa.); Oberlin (Ohio);</dcterms:spatial>
+      <dcterms:spatial>Lombard Street (Philadelphia, Pa.); Oberlin (Ohio);</dcterms:spatial>
+      <dcterms:date>1866-04-30</dcterms:date>
+      <dcterms:subject>African American fathers</dcterms:subject>
+      <dcterms:subject> Fathers and daughters</dcterms:subject>
+      <dcterms:subject> African American businesspeople</dcterms:subject>
+      <dcterms:subject> African American abolitionists</dcterms:subject>
+      <dcterms:subject>Anderson, Caroline Still, 1848-1911 [recipient]</dcterms:subject>
+      <dcterms:subject> Cassey, Joseph, 1789-1848</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:language>English</dcterms:language>
+      <dcterms:type>Text</dcterms:type>
+      <dcterms:rights>Public domain</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-missingitemurl</dcterms:identifier>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Ella Fitzgerald</dcterms:title>
+      <dcterms:creator>Mosley, John W.</dcterms:creator>
+      <dcterms:description>Ella Fitzgerald (1917-1996), also known as “Lady Ella” and the “First
+         Lady of Song.”, as early as the age of 17 performed songs by Connee Boswell to win “Amateur
+         Night” at Harlem New York’s Apollo Theatre. After four years as a singer in Chick Webb’s
+         Orchestra, Fitzgerald in 1939 took on the leadership of the band, and it was renamed Ella
+         and her Famous Orchestra. The band recorded together until 1942 when Fitzgerald began her
+         solo career. For her jazz vocals she won 13 Grammy awards including the coveted Best Female
+         Vocalist category for three years in a row.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Testing circa date</dcterms:description>
+      <dcterms:subject>African American jazz musicians</dcterms:subject>
+      <dcterms:subject> Fitzgerald, Ella</dcterms:subject>
+      <dcterms:format>banana;peach</dcterms:format>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, the Charles L. Blockson Afro-American Collection (blockson@temple.edu;
+         215-204-6632)</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-missingprovider</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/12</edm:isShownAt>
+      <dcterms:isPartOf>John W. Mosley Photograph Collection</dcterms:isPartOf>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Wise Acres 1914 March</dcterms:title>
+      <dcterms:description>Yearbook of the Pennsylvania School of Horticulture for Women Vol. I No.
+         1</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test local rights and DPLA rights.</dcterms:description>
+      <dcterms:date>1914-03</dcterms:date>
+      <dcterms:subject>Temple University--School of Environmental
+         Design--Students--Periodicals</dcterms:subject>
+      <dcterms:subject> Temple University--School of Environmental
+         Design--Students--Yearbooks</dcterms:subject>
+      <dcterms:subject>Horticulture Students--Periodicals</dcterms:subject>
+      <dcterms:type>Text</dcterms:type>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, Special Collection Research Center, scrc@temple.edu,
+         215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>invalid-malformeditemurl</dcterms:identifier>
+      <edm:isShownAt>id/33</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Micky Dolenz of the Monkees with the Temple owl mascot and a Temple University
+         football player</dcterms:title>
+      <dcterms:description>Micky Dolenz identified from other photos of the Monkees rock group. The
+         Monkees played a concert at a Temple University football game. The date of the
+         concert/football game was found to be 1986 through research in newspaper
+         databases.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Circa date. Test coverage-temporal and range in
+         coverage.</dcterms:description>
+      <dcterms:spatial>1985-1987</dcterms:spatial>
+      <dcterms:temporal>1985-1987</dcterms:temporal>
+      <dcterms:date>circa=1986</dcterms:date>
+      <dcterms:subject>Football players</dcterms:subject>
+      <dcterms:subject>Mascots</dcterms:subject>
+      <dcterms:subject>Musicians</dcterms:subject>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>Public domain</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>valid2</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/34</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Russell Conwell and others at the dedication of Conwell Hall</dcterms:title>
+      <dcterms:description>"Participants in the dedication of Conwell Hall in January of 1924
+         included (from the left) Josiah Penniman, President of the University of Pennsylvania; the
+         Rev. Floyd Tomkins, rector of Holy Trinity Protestant Episcopal Church; President Conwell;
+         Charles E. Beury, Trustee and Chairman of the Building Committee; Laura Carnell, Associate
+         President; Wilmer Krusen, Vice President of the University and Philadelphia's Director of
+         Health."</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test local rights and DPLA rights.</dcterms:description>
+      <dcterms:date>1924-01-23</dcterms:date>
+      <dcterms:subject>Conwell, Russell Herman, 1843-1925</dcterms:subject>
+      <dcterms:subject> Penniman, Josiah Harmar, 1868-1941</dcterms:subject>
+      <dcterms:subject> Tomkins, Floyd W. (Floyd Williams), 1850-1932</dcterms:subject>
+      <dcterms:subject> Beury, Charles Ezra, 1879-1953</dcterms:subject>
+      <dcterms:subject> Carnell, Laura, 1867-1929</dcterms:subject>
+      <dcterms:subject>Krusen, Wilmer</dcterms:subject>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, Special Collections Research Center, scrc@temple.edu,
+         215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>valid3</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/35</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+</metadata>

--- a/tests/fixtures/sch-oai-valid.xml
+++ b/tests/fixtures/sch-oai-valid.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+   xmlns:edm="http://www.europeana.eu/schemas/edm/"
+   xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/"
+   xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+   xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+   <oai_dc:dc>
+      <dcterms:title>Celebration at Independence Hall</dcterms:title>
+      <dcterms:creator>pdcp_noharvest</dcterms:creator>
+      <dcterms:creator>Philadelphia Evening Bulletin</dcterms:creator>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:publisher>Philadelphia Evening Bulletin</dcterms:publisher>
+      <dcterms:description>Photo shows pennants and streamers hanging from clock and bell tower of
+         Independence Hall and Commodore John Barry monument. There is a tent and loud speaker
+         system immediately in front of Independence Hall entrance. Note dirigible in left upper
+         quadrant of photo.</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:spatial>Philadelphia (Pa.);Independence National Historical Park (Philadelphia,
+         Pa.)</dcterms:spatial>
+      <dcterms:date>1924</dcterms:date>
+      <dcterms:subject>Statues</dcterms:subject>
+      <dcterms:subject/>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>This material is made available for private study, scholarship, and research
+         use. For access to the original, contact: Temple University Libraries. Special Collections
+         Research Center, scrc@temple.edu, 215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2</schema:fileFormat>
+      <dcterms:identifier>valid</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/0</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Micky Dolenz of the Monkees with the Temple owl mascot and a Temple University
+         football player</dcterms:title>
+      <dcterms:description>Micky Dolenz identified from other photos of the Monkees rock group. The
+         Monkees played a concert at a Temple University football game. The date of the
+         concert/football game was found to be 1986 through research in newspaper
+         databases.</dcterms:description>
+      <dcterms:spatial>1985-1987</dcterms:spatial>
+      <dcterms:temporal>1985-1987</dcterms:temporal>
+      <dcterms:date>circa=1986</dcterms:date>
+      <dcterms:subject>Football players</dcterms:subject>
+      <dcterms:subject>Mascots</dcterms:subject>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, Special Collection Research Center, scrc@temple.edu,
+         215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>valid2</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/34</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+   <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/"
+      xmlns:edm="http://www.europeana.eu/schemas/edm/"
+      xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+      xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org"
+      xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+      xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">
+      <dcterms:title>Russell Conwell and others at the dedication of Conwell Hall</dcterms:title>
+      <dcterms:description>"Participants in the dedication of Conwell Hall in January of 1924
+         included (from the left) Josiah Penniman, President of the University of Pennsylvania; the
+         Rev. Floyd Tomkins, rector of Holy Trinity Protestant Episcopal Church; President Conwell;
+         Charles E. Beury, Trustee and Chairman of the Building Committee; Laura Carnell, Associate
+         President; Wilmer Krusen, Vice President of the University and Philadelphia's Director of
+         Health."</dcterms:description>
+      <dcterms:description>This is a test record from the PDCP Metadata Team. Please do not
+         reference this item for research. Thank you.</dcterms:description>
+      <dcterms:description>Test local rights and DPLA rights.</dcterms:description>
+      <dcterms:date>1924-01-23</dcterms:date>
+      <dcterms:subject>Conwell, Russell Herman, 1843-1925</dcterms:subject>
+      <dcterms:subject> Penniman, Josiah Harmar, 1868-1941</dcterms:subject>
+      <dcterms:subject> Tomkins, Floyd W. (Floyd Williams), 1850-1932</dcterms:subject>
+      <dcterms:subject> Beury, Charles Ezra, 1879-1953</dcterms:subject>
+      <dcterms:subject> Carnell, Laura, 1867-1929</dcterms:subject>
+      <dcterms:subject>Krusen, Wilmer</dcterms:subject>
+      <dcterms:type>Image</dcterms:type>
+      <dcterms:rights>This material is subject to copyright law and is made available for private
+         study, scholarship, and research purposes only. For access to the original or a high
+         resolution reproduction, and for permission to publish, please contact Temple University
+         Libraries, Special Collections Research Center, scrc@temple.edu,
+         215-204-8257.</dcterms:rights>
+      <schema:fileFormat>image/jp2;</schema:fileFormat>
+      <dcterms:identifier>valid3</dcterms:identifier>
+      <edm:isShownAt>http://digital.library.temple.edu/cdm/ref/collection/p16002coll25/id/35</edm:isShownAt>
+      <edm:dataProvider>Temple University Libraries</edm:dataProvider>
+      <edm:provider>PA Digital</edm:provider>
+   </oai_dc:dc>
+</metadata>

--- a/tests/fixtures/sch-sample.sch
+++ b/tests/fixtures/sch-sample.sch
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/">
+    <ns prefix="dcterms" uri="http://purl.org/dc/terms/"/>
+    <ns prefix="edm" uri="http://www.europeana.eu/schemas/edm/"/>
+    <ns prefix="oai_dc" uri="http://www.openarchives.org/OAI/2.0/oai_dc/"/>
+    <!-- Required Fields -->
+    <pattern id="RequiredElementsPattern">
+        <title>Required PA Digital Elements</title>
+        <rule context="oai_dc:dc">
+            <assert test="dcterms:title" id="Required1" role="error">There must be a title</assert>
+            <assert test="dcterms:rights or edm:rights" id="Required2" role="error">There must be a rights statement</assert>
+            <assert test="edm:isShownAt" id="Required3" role="error">There must be a trackback URL</assert>
+            <assert test="edm:dataProvider" id="Required4" role="error">There must be a contributing institution</assert>
+        </rule>
+    </pattern>
+    <pattern id="TitleElementPattern">
+        <title>Additional Title Requirements</title>
+        <rule context="oai_dc:dc/dcterms:title">
+            <assert test="normalize-space(.)" id="Title1" role="error">The title element must contain text</assert>
+        </rule>
+    </pattern>
+    <pattern id="DCTRightsElementPattern">
+        <title>Additional Rights Requirements</title>
+        <rule context="oai_dc:dc/dcterms:rights">
+            <assert test="normalize-space(.)" id="DCTRights1" role="error">dcterms:rights must contain text</assert>
+        </rule>
+    </pattern>
+    <pattern id="EDMRightsElementPattern">
+        <title>Additional Rights Requirements</title>
+        <rule context="oai_dc:dc/edm:rights">
+            <assert test="normalize-space(.)" id="EDMRights1" role="error">edm:rights must contain text</assert>
+        </rule>
+    </pattern>
+    <pattern id="ItemURLElementPattern">
+        <title>Additional Trackback URL Requirements</title>
+        <rule context="oai_dc:dc/edm:isShownAt">
+            <assert test="normalize-space(.)" id="ItemURL1" role="error">The trackback URL must contain text</assert>
+            <assert test="starts-with(normalize-space(.),'http')">edm:isShownAt must contain a URL</assert>
+        </rule>
+    </pattern>
+    <pattern id="EDMDataProviderElementPattern">
+        <title>Additional Contributing Institution Requirements</title>
+        <rule context="oai_dc:dc/edm:dataProvider">
+            <assert test="normalize-space(.)" id="EDMDp1" role="error">edm:dataProvider must contain text</assert>
+        </rule>
+    </pattern>
+</schema>

--- a/tests/fixtures/temple.xsl
+++ b/tests/fixtures/temple.xsl
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Funcake name: 'Temple'
+    Use: Imported by Temple ContentDM Collection-level Transforms for Shared Templates.-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:dpla="http://dp.la/about/map/"
+    xmlns:padig="http://padigital.org/ns"
+    xmlns:edm="http://www.europeana.eu/schemas/edm/"
+    xmlns:oclcdc="http://worldcat.org/xmlschemas/oclcdc-1.0/"
+    xmlns:oclcterms="http://purl.org/oclc/terms/"
+    xmlns:oai="http://www.openarchives.org/OAI/2.0/"
+    xmlns:oai_dc='http://www.openarchives.org/OAI/2.0/oai_dc/'
+    xmlns:oclc="http://purl.org/oclc/terms/"
+    xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/"
+    xmlns:schema="http://schema.org"
+    xmlns:svcs="http://rdfs.org/sioc/services"
+    version="2.0">
+    <xsl:output omit-xml-declaration="no" method="xml" encoding="UTF-8" indent="yes"/>
+
+     <!-- Use includes here if you need to separate out templates for either use specific to a dataset or use generic enough for multiple providers (like remediation.xslt). -->
+    <!-- For using this XSLT in Combine, you need to replace the following with an actionable HTTP link to the remediation XSLT, or load both XSLT into Combine then rename this to the filepath & name assigned to remediation.xslt within Combine. -->
+
+    <xsl:include href="https://raw.githubusercontent.com/tulibraries/aggregator_mdx/master/transforms/remediations/lookup.xsl"/>
+
+     <!-- Title -->
+    <xsl:template match="dc:title">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:title">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Alternative titles -->
+     <xsl:template match="dcterms:alternative">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:alternative">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Type -->
+    <xsl:template match="dc:type">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:choose>
+                <xsl:when test="matches(., '(^text.*$)', 'i')">
+                    <dcterms:type>Text</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(., '(^image.*$)', 'i')">
+                    <dcterms:type>Image</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(., '^(movingimage.*$|moving\simage.*$)', 'i')">
+                    <dcterms:type>Moving Image</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(., '^(sound.*$)', 'i')">
+                    <dcterms:type>Sound</dcterms:type>
+                </xsl:when>
+                <xsl:when test="matches(., '^(physicalobject.*$|physical\sobject.*$)', 'i')">
+                    <dcterms:type>Physical Object</dcterms:type>
+                </xsl:when>
+                <xsl:when
+                    test="matches(., '^(interactiveresource.*$|interactive\sresource.*$)', 'i')">
+                    <dcterms:type>Interactive Resource</dcterms:type>
+                </xsl:when>
+                <xsl:when
+                    test="matches(., '^(stillimage.*$|still\simage.*$)', 'i')">
+                    <dcterms:type>Still Image</dcterms:type>
+                </xsl:when>
+
+    <!-- Format -->
+                <xsl:otherwise>
+                    <dcterms:format>
+                        <xsl:value-of select="."/>
+                    </dcterms:format>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Creator -->
+    <xsl:template match="dc:creator">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:creator">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Source; uncomment when not used by DPLAH crosswalk
+    <xsl:template match="dc:source">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:source">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+    -->
+
+     <!-- Publisher -->
+    <xsl:template match="dc:publisher">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:publisher">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Description -->
+    <xsl:template match="dc:description">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:description">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Place (when oai_dc used) -->
+    <xsl:template match="dc:coverage">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:spatial">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Place -->
+    <xsl:template match="dcterms:spatial">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:spatial">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Temporal coverage -->
+    <xsl:template match="dcterms:temporal">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:temporal">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Extent -->
+    <xsl:template match="dcterms:extent">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:extent">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Date -->
+    <xsl:template match="dc:date">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:date">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Subject -->
+    <xsl:template match="dc:subject">
+        <xsl:call-template name="subj_template">
+            <xsl:with-param name="stringz" select="."/>
+            <xsl:with-param name="delimiter" select="';'"/>
+        </xsl:call-template>
+    </xsl:template>
+
+     <!-- Language -->
+    <xsl:template match="dc:language">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:language">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+    <!-- Language (Remediated) -->
+    <!--
+    <xsl:template match="dc:language">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:variable name="langterm" select="normalize-space(lower-case(.))"/>
+            <xsl:if test="$langterm = $lexvoLang/padig:language">
+                <xsl:element name="dcterms:language">
+                    <xsl:value-of select="$lexvoLang/padig:language[. = $langterm]/@string"/>
+                </xsl:element>
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
+     -->
+
+     <!-- Relation; uncomment after migration
+    <xsl:template match="dc:relation">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:relation">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+    -->
+
+     <!-- isPartOf -->
+    <xsl:template match="dcterms:isPartOf">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:isPartOf">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Replaced by -->
+    <xsl:template match="dcterms:isReplacedBy">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:isReplacedBy">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Replaces -->
+    <xsl:template match="dcterms:replaces">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:replaces">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Rights -->
+    <xsl:template match="dc:rights">
+        <xsl:choose>
+            <!-- Rights URI -->
+            <xsl:when
+                test="starts-with(., 'http://rightsstatements.org/vocab/') or starts-with(., 'http://creativecommons.org/') or starts-with(., 'https://creativecommons.org/')">
+                <xsl:if test="normalize-space(.)!=''">
+                    <xsl:element name="edm:rights">
+                        <xsl:value-of select="normalize-space(.)"/>
+                    </xsl:element>
+                </xsl:if>
+            </xsl:when>
+            <!-- Rights text -->
+            <xsl:otherwise>
+                <xsl:if test="normalize-space(.)!=''">
+                    <xsl:element name="dcterms:rights">
+                        <xsl:value-of select="normalize-space(.)"/>
+                    </xsl:element>
+                </xsl:if>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+     <!-- Rights holder -->
+    <xsl:template match="dcterms:rightsholder">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:rightsholder">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+
+     <!-- Identifier; uncomment after migration
+    <xsl:template match="dc:identifier[1]">
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:element name="dcterms:identifier">
+                <xsl:value-of select="normalize-space(.)"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+    -->
+
+    <!-- Create $baseURL and $objID; uncomment after migration
+    <xsl:template match="dc:identifier[2]">
+        <xsl:variable name="objID" select='substring-after(.,"/cdm/ref/")'/>
+        <xsl:variable name="baseURL" select='substring-before(.,"/cdm/ref/")'/>
+     -->
+        <!-- Contributing Institution
+        <xsl:if test="normalize-space(.)!=''">
+            <xsl:if test="$baseURL = $oaiUrl/padig:url">
+                <xsl:element name="edm:dataProvider">
+                    <xsl:value-of select="$oaiUrl/padig:url[. = $baseURL]/@string"/>
+                </xsl:element>
+            </xsl:if>
+        </xsl:if>
+    </xsl:template>
+     -->
+
+        <!-- URL
+            <xsl:element name="edm:isShownAt">
+                <xsl:value-of select="$baseURL"/> <xsl:text>/cdm/ref/</xsl:text><xsl:value-of select="$objID"/>
+            </xsl:element>
+        -->
+
+        <!-- Thumbnail
+            <xsl:element name="edm:preview">
+                <xsl:value-of select="$baseURL"/> <xsl:text>/utils/getthumbnail/</xsl:text><xsl:value-of select="$objID"/>
+            </xsl:element>
+        </xsl:if>
+    </xsl:template>
+        -->
+
+
+     <!-- NAMED TEMPLATES -->
+
+     <!-- Contributing institution (Hard-coded); should be able to remove if lookup works
+    <xsl:template name="dataProvider">
+        <xsl:element name="edm:dataProvider">
+            <xsl:value-of><xsl:text>INSERT CONTRIBUTING INSTITUTION HERE</xsl:text></xsl:value-of>
+        </xsl:element>
+    </xsl:template>
+    -->
+
+     <!-- Hub -->
+    <xsl:template name="hub">
+        <xsl:element name="edm:provider">
+            <xsl:value-of>PA Digital</xsl:value-of>
+        </xsl:element>
+    </xsl:template>
+
+     <!-- Subject -->
+    <xsl:template name="subj_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+         <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:subject>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:subject>
+
+                 <!--Need to do recursion-->
+                <xsl:call-template name="subj_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="';'"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:subject>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:subject>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+     <!-- Type -->
+    <xsl:template name="type_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+         <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:type>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:type>
+
+                 <!--Need to do recursion-->
+                <xsl:call-template name="type_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="'; '"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:type>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:type>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+
+     <!-- Language -->
+    <xsl:template name="lang_template">
+        <xsl:param name="stringz"/>
+        <xsl:param name="delimiter"/>
+
+         <xsl:choose>
+            <!-- IF A PAREN, STOP AT AN OPENING semicolon -->
+            <xsl:when test="contains($stringz, $delimiter)">
+                <xsl:variable name="newstem" select="substring-after($stringz, $delimiter)"/>
+                <dcterms:language>
+                    <xsl:value-of select="substring-before($stringz, $delimiter)"/>
+                </dcterms:language>
+
+                 <!--Need to do recursion-->
+                <xsl:call-template name="lang_template">
+                    <xsl:with-param name="stringz" select="$newstem"/>
+                    <xsl:with-param name="delimiter" select="'; '"/>
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <dcterms:language>
+                    <xsl:value-of select="normalize-space($stringz)"/>
+                </dcterms:language>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:template>
+</xsl:stylesheet>

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -118,7 +118,7 @@ class TestDataProcessInteractions(unittest.TestCase):
         filename = "transforms/temple.xsl"
 
         test_run = process.get_github_content(repository, filename)
-        self.assertEqual(test_run, open("tests/fixtures/temple.xsl").read())
+        self.assertEqual(test_run, open("tests/fixtures/temple.xsl", "rb").read())
 
     @httpretty.activate
     def test_get_github_content_missing(self):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,238 @@
+"""Tests suite for tulflow.validate (functions for validating XML or JSON in Airflow Tasks)."""
+import unittest
+import boto3
+from lxml import etree
+from moto import mock_s3
+from tulflow import process, validate
+import logging
+from mock import patch
+
+class TestSchematronValidation(unittest.TestCase):
+    """Test Class for functions that validating & filtering XML with Schematron."""
+    maxDiff = None
+    kwargs = {
+        "source_prefix": "dpla_test/transformed",
+        "destination_prefix": "dpla_test/transformed-filtered",
+        "bucket": "tulib-airflow-test",
+        "record_parent_element": "{http://www.openarchives.org/OAI/2.0/oai_dc/}dc",
+        "schematron_filename": "validations/padigital_reqd_fields.sch",
+        "access_id": "kittens",
+        "access_secret": "puppies"
+    }
+
+    @mock_s3
+    @patch("tulflow.process.get_github_content")
+    def test_filter_s3_schematron_all_valid(self, mocked_get_github_content):
+        """Test Filtering S3 XML File with Schematron."""
+        # setup kwargs for test runs
+        access_id = self.kwargs.get("access_id")
+        access_secret = self.kwargs.get("access_secret")
+        bucket = self.kwargs.get("bucket")
+        test_key = self.kwargs.get("source_prefix") + "/sch-oai-valid.xml"
+
+        # create expected mocked s3 resources
+        conn = boto3.client("s3", aws_access_key_id=access_id, aws_secret_access_key=access_secret)
+        conn.create_bucket(Bucket=bucket)
+        conn.put_object(Bucket=bucket, Key=test_key, Body=open("tests/fixtures/sch-oai-valid.xml").read())
+        test_content_exists = conn.get_object(Bucket=bucket, Key=test_key)
+        test_object_exists = conn.list_objects(Bucket=bucket)
+        self.assertEqual(test_content_exists["Body"].read(), open("tests/fixtures/sch-oai-valid.xml", "rb").read())
+        self.assertEqual(test_content_exists["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_object_exists["Contents"][0]["Key"], test_key)
+
+        # mock schematron github retrieval response
+        mocked_get_github_content.return_value = open("tests/fixtures/sch-sample.sch").read()
+
+        # run tests
+        with self.assertLogs() as log:
+            validate.filter_s3_schematron(**self.kwargs)
+        self.assertIn("INFO:root:Validating & Filtering File: dpla_test/transformed/sch-oai-valid.xml", log.output)
+        test_valid_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix"))
+        test_valid_objects_ar = [object.get("Key") for object in test_valid_objects["Contents"]]
+        self.assertEqual(test_valid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_valid_objects_ar, ["dpla_test/transformed-filtered/sch-oai-valid.xml"])
+        test_invalid_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix") + "-invalid")
+        self.assertEqual(test_invalid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_invalid_objects.get("Contents"), None)
+
+
+    @mock_s3
+    @patch("tulflow.process.get_github_content")
+    def test_filter_s3_schematron_all_invalid(self, mocked_get_github_content):
+        """Test Filtering S3 XML File with Schematron."""
+        # setup kwargs for test runs
+        access_id = self.kwargs.get("access_id")
+        access_secret = self.kwargs.get("access_secret")
+        bucket = self.kwargs.get("bucket")
+        test_key = self.kwargs.get("source_prefix") + "/sch-oai-invalid.xml"
+
+        # create expected mocked s3 resources
+        conn = boto3.client("s3", aws_access_key_id=access_id, aws_secret_access_key=access_secret)
+        conn.create_bucket(Bucket=bucket)
+        conn.put_object(Bucket=bucket, Key=test_key, Body=open("tests/fixtures/sch-oai-invalid.xml").read())
+        test_content_exists = conn.get_object(Bucket=bucket, Key=test_key)
+        test_object_exists = conn.list_objects(Bucket=bucket)
+        self.assertEqual(test_content_exists["Body"].read(), open("tests/fixtures/sch-oai-invalid.xml", "rb").read())
+        self.assertEqual(test_content_exists["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_object_exists["Contents"][0]["Key"], test_key)
+
+        # mock schematron github retrieval response
+        mocked_get_github_content.return_value = open("tests/fixtures/sch-sample.sch").read()
+
+        # run tests
+        with self.assertLogs() as log:
+            validate.filter_s3_schematron(**self.kwargs)
+        self.assertIn("INFO:root:Validating & Filtering File: dpla_test/transformed/sch-oai-invalid.xml", log.output)
+        self.assertIn("ERROR:root:Invalid record found:", log.output[1])
+        self.assertIn("<dcterms:identifier>invalid-missingtitle</dcterms:identifier>", log.output[1])
+        self.assertIn("ERROR:root:Schematron Report:", log.output[2])
+        self.assertIn("<svrl:text>There must be a title</svrl:text>", log.output[2])
+        self.assertIn("ERROR:root:Invalid record found:", log.output[3])
+        self.assertIn("<dcterms:identifier>invalid-missingrights</dcterms:identifier>", log.output[3])
+        self.assertIn("ERROR:root:Schematron Report:", log.output[4])
+        self.assertIn("<svrl:text>There must be a rights statement</svrl:text>", log.output[4])
+        self.assertEqual(len(log.output), 11)
+        test_valid_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix") + "/")
+        test_valid_objects_ar = [object.get("Key") for object in test_valid_objects["Contents"]]
+        test_valid_content = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered/sch-oai-invalid.xml")
+        self.assertEqual(test_valid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_valid_objects_ar, ["dpla_test/transformed-filtered/sch-oai-invalid.xml"])
+        self.assertEqual(test_valid_content["Body"].read(), b"""<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">\n   </metadata>""")
+
+        invalid_prefix = self.kwargs.get("destination_prefix") + "-invalid/"
+        test_invalid_objects = conn.list_objects(Bucket=bucket, Prefix=invalid_prefix)
+        test_invalid_objects_ar = [object.get("Key") for object in test_invalid_objects["Contents"]]
+        test_invalid_content_xml = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered-invalid/sch-oai-invalid.xml1")
+        test_invalid_content_report = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered-invalid/sch-oai-invalid.xml1-report")
+        self.assertEqual(test_invalid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-invalid.xml1", test_invalid_objects_ar)
+        self.assertEqual(len(test_invalid_objects_ar), 10)
+        self.assertIn(b"<dcterms:identifier>invalid-missingtitle</dcterms:identifier>", test_invalid_content_xml["Body"].read())
+        self.assertIn(b"<svrl:text>There must be a rights statement</svrl:text>", test_invalid_content_report["Body"].read())
+
+
+    @mock_s3
+    @patch("tulflow.process.get_github_content")
+    def test_filter_s3_schematron_mix(self, mocked_get_github_content):
+        """Test Filtering S3 XML File with Schematron."""
+        # setup kwargs for test runs
+        access_id = self.kwargs.get("access_id")
+        access_secret = self.kwargs.get("access_secret")
+        bucket = self.kwargs.get("bucket")
+        test_key = self.kwargs.get("source_prefix") + "/sch-oai-mix.xml"
+
+        # create expected mocked s3 resources
+        conn = boto3.client("s3", aws_access_key_id=access_id, aws_secret_access_key=access_secret)
+        conn.create_bucket(Bucket=bucket)
+        conn.put_object(Bucket=bucket, Key=test_key, Body=open("tests/fixtures/sch-oai-mix.xml").read())
+        test_content_exists = conn.get_object(Bucket=bucket, Key=test_key)
+        test_object_exists = conn.list_objects(Bucket=bucket)
+        self.assertEqual(test_content_exists["Body"].read(), open("tests/fixtures/sch-oai-mix.xml", "rb").read())
+        self.assertEqual(test_content_exists["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_object_exists["Contents"][0]["Key"], test_key)
+
+        # mock schematron github retrieval response
+        mocked_get_github_content.return_value = open("tests/fixtures/sch-sample.sch").read()
+
+        # run tests
+        with self.assertLogs() as log:
+            validate.filter_s3_schematron(**self.kwargs)
+        self.assertIn("INFO:root:Validating & Filtering File: dpla_test/transformed/sch-oai-mix.xml", log.output)
+        self.assertIn("ERROR:root:Invalid record found:", log.output[1])
+        self.assertIn("<dcterms:identifier>invalid-missingtitle</dcterms:identifier>", log.output[1])
+        self.assertIn("ERROR:root:Schematron Report:", log.output[2])
+        self.assertIn("<svrl:text>There must be a title</svrl:text>", log.output[2])
+        self.assertIn("ERROR:root:Invalid record found:", log.output[3])
+        self.assertIn("<dcterms:identifier>invalid-missingrights</dcterms:identifier>", log.output[3])
+        self.assertIn("ERROR:root:Schematron Report:", log.output[4])
+        self.assertIn("<svrl:text>There must be a rights statement</svrl:text>", log.output[4])
+        self.assertEqual(len(log.output), 11)
+
+        test_valid_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix") + "/")
+        test_valid_objects_ar = [object.get("Key") for object in test_valid_objects["Contents"]]
+        test_valid_content = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered/sch-oai-mix.xml")["Body"].read()
+        self.assertEqual(test_valid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_valid_objects_ar, ["dpla_test/transformed-filtered/sch-oai-mix.xml"])
+        self.assertIn(b"<oai_dc:dc>", test_valid_content)
+        self.assertIn(b"<dcterms:identifier>valid</dcterms:identifier>", test_valid_content)
+        self.assertIn(b"<dcterms:identifier>valid2</dcterms:identifier>", test_valid_content)
+        self.assertIn(b"<dcterms:identifier>valid3</dcterms:identifier>", test_valid_content)
+
+        invalid_prefix = self.kwargs.get("destination_prefix") + "-invalid/"
+        test_invalid_objects = conn.list_objects(Bucket=bucket, Prefix=invalid_prefix)
+        test_invalid_objects_ar = [object.get("Key") for object in test_invalid_objects["Contents"]]
+        test_invalid_content_xml = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered-invalid/sch-oai-mix.xml2")
+        test_invalid_content_report = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered-invalid/sch-oai-mix.xml2-report")
+        self.assertEqual(test_invalid_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml2", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml2-report", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml3", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml3-report", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml4", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml4-report", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml5", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml5-report", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml6", test_invalid_objects_ar)
+        self.assertIn("dpla_test/transformed-filtered-invalid/sch-oai-mix.xml6-report", test_invalid_objects_ar)
+        self.assertEqual(len(test_invalid_objects_ar), 10)
+        self.assertIn(b"<dcterms:identifier>invalid-missingtitle</dcterms:identifier>", test_invalid_content_xml["Body"].read())
+        self.assertIn(b"<svrl:text>There must be a rights statement</svrl:text>", test_invalid_content_report["Body"].read())
+
+
+    @mock_s3
+    @patch("tulflow.process.get_github_content")
+    def test_filter_s3_schematron_empty(self, mocked_get_github_content):
+        """Test Filtering S3 XML File with Schematron."""
+        # setup kwargs for test runs
+        access_id = self.kwargs.get("access_id")
+        access_secret = self.kwargs.get("access_secret")
+        bucket = self.kwargs.get("bucket")
+        test_key = self.kwargs.get("source_prefix") + "/sch-oai-empty.xml"
+
+        # create expected mocked s3 resources
+        conn = boto3.client("s3", aws_access_key_id=access_id, aws_secret_access_key=access_secret)
+        conn.create_bucket(Bucket=bucket)
+        conn.put_object(Bucket=bucket, Key=test_key, Body=open("tests/fixtures/sch-oai-empty.xml").read())
+        test_content_exists = conn.get_object(Bucket=bucket, Key=test_key)
+        test_object_exists = conn.list_objects(Bucket=bucket)
+        self.assertEqual(test_content_exists["Body"].read(), open("tests/fixtures/sch-oai-empty.xml", "rb").read())
+        self.assertEqual(test_content_exists["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_object_exists["Contents"][0]["Key"], test_key)
+
+        # mock schematron github retrieval response
+        mocked_get_github_content.return_value = open("tests/fixtures/sch-sample.sch").read()
+
+        # run tests
+        with self.assertLogs() as log:
+            validate.filter_s3_schematron(**self.kwargs)
+        self.assertEqual(["INFO:root:Validating & Filtering File: dpla_test/transformed/sch-oai-empty.xml"], log.output)
+        test_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix") + "/")
+        test_objects_ar = [object.get("Key") for object in test_objects["Contents"]]
+        test_content = conn.get_object(Bucket=bucket, Key="dpla_test/transformed-filtered/sch-oai-empty.xml")
+        self.assertEqual(test_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_objects_ar, ["dpla_test/transformed-filtered/sch-oai-empty.xml"])
+        self.assertEqual(test_content["Body"].read(), b"""<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edm="http://www.europeana.eu/schemas/edm/" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dpla="http://dp.la/about/map/" xmlns:schema="http://schema.org" xmlns:oai="http://www.openarchives.org/OAI/2.0/" xmlns:oai_qdc="http://worldcat.org/xmlschemas/qdc-1.0/">\n</metadata>""")
+
+
+    @mock_s3
+    @patch("tulflow.process.get_github_content")
+    def test_filter_s3_schematron_none(self, mocked_get_github_content):
+        """Test Filtering S3 XML File with Schematron."""
+        # setup kwargs for test runs
+        access_id = self.kwargs.get("access_id")
+        access_secret = self.kwargs.get("access_secret")
+        bucket = self.kwargs.get("bucket")
+        test_key = self.kwargs.get("source_prefix") + "/sch-oai-none.xml"
+
+        # create expected mocked s3 resources
+        conn = boto3.client("s3", aws_access_key_id=access_id, aws_secret_access_key=access_secret)
+        conn.create_bucket(Bucket=bucket)
+
+        # mock schematron github retrieval response
+        mocked_get_github_content.return_value = open("tests/fixtures/sch-sample.sch").read()
+
+        # run tests
+        validate.filter_s3_schematron(**self.kwargs)
+        test_objects = conn.list_objects(Bucket=bucket, Prefix=self.kwargs.get("destination_prefix") + "/")
+        self.assertEqual(test_objects["ResponseMetadata"]["HTTPStatusCode"], 200)
+        self.assertEqual(test_objects.get("Contents"), None)

--- a/tulflow/process.py
+++ b/tulflow/process.py
@@ -81,7 +81,7 @@ def get_github_content(repository, filename, branch="master"):
     try:
         resp = requests.get(raw_url)
         resp.raise_for_status()
-        return resp.text
+        return resp.content
     except requests.exceptions.RequestException as error:
         logging.error(error)
         sys.exit(1)

--- a/tulflow/validate.py
+++ b/tulflow/validate.py
@@ -1,0 +1,50 @@
+"""Generic Data (primarily XML & JSON) Validation Methods."""
+from lxml import etree, isoschematron
+import logging
+from tulflow import process
+
+
+def filter_s3_schematron(**kwargs):
+    """Wrapper function for using S3 Retrieval, Schematron Filtering, and S3 Writer."""
+    source_prefix = kwargs.get("source_prefix")
+    dest_prefix = kwargs.get("destination_prefix")
+    bucket = kwargs.get("bucket")
+    record_element = kwargs.get("record_parent_element")
+    schematron_file = kwargs.get("schematron_filename")
+    access_id = kwargs.get("access_id")
+    access_secret = kwargs.get("access_secret")
+
+    # get schematron doc & return lxml.etree.Schematron validator
+    schematron_doc = process.get_github_content("tulibraries/aggregator_mdx", schematron_file)
+    schematron = isoschematron.Schematron(etree.fromstring(schematron_doc), store_report=True)
+
+    for s3_key in process.list_s3_content(bucket, access_id, access_secret, source_prefix):
+        logging.info("Validating & Filtering File: %s", s3_key)
+        s3_content = process.get_s3_content(bucket, s3_key, access_id, access_secret)
+        s3_xml = etree.fromstring(s3_content)
+        record_count = 0
+        for record in s3_xml.findall(record_element):
+            record_count += 1
+            if not schematron.validate(record):
+                logging.error("Invalid record found: %s", etree.tostring(record))
+                logging.error("Schematron Report: %s", etree.tostring(schematron.validation_report))
+                error_dest_prefix = dest_prefix + "-invalid"
+                error_filename = s3_key.replace(source_prefix, error_dest_prefix) + str(record_count)
+                process.generate_s3_object(
+                    etree.tostring(record),
+                    bucket,
+                    error_filename,
+                    access_id,
+                    access_secret
+                )
+                process.generate_s3_object(
+                    etree.tostring(schematron.validation_report),
+                    bucket,
+                    error_filename + "-report",
+                    access_id,
+                    access_secret
+                )
+                s3_xml.remove(record)
+        filename = s3_key.replace(source_prefix, dest_prefix)
+        updated_s3_xml = etree.tostring(s3_xml)
+        process.generate_s3_object(updated_s3_xml, bucket, filename, access_id, access_secret)


### PR DESCRIPTION
What this PR does:
- add a schematron wrapper function to be called by Airflow to validate XML in S3 with a GitHub schematron, write the valid records to another S3 folder, and write the invalid records + their schematron reports to yet another S3 folder.
- adds a shit ton of tests & fixtures for the above
- add a GitHub content retrieval function for getting GitHub files (public repos only)