### PR TITLE
Remove init collections and parameterize refresh task

### DIFF
--- a/tests/test_solr_api_utils.py
+++ b/tests/test_solr_api_utils.py
@@ -71,6 +71,15 @@ class TestSolrApiUtils(unittest.TestCase):
         nothingness = self.solrcloud.collection_exists('sartre')
         self.assertFalse(nothingness)
 
+    def test_filter_init_collection(self):
+        aliases = ["test-init", "test-real", "test-realer"]
+        #uses default of ending with "-init"
+        filtered = self.solrcloud.filter_init_collection(aliases)
+        self.assertFalse("test-init" in filtered)
+        # Also accepts specific name
+        filtered = self.solrcloud.filter_init_collection(aliases, "test-realer")
+        self.assertFalse("test-realer" in filtered)
+
     @patch('tulflow.solr_api_utils.SolrApiUtils.create_or_modify_alias_and_set_collections')
     @patch('tulflow.solr_api_utils.SolrApiUtils.get_alias_collections')
     def test_remove_collection_from_alias(self, mock_get_alias_collections, mock_create_or_modify_alias_and_set_collections):
@@ -102,10 +111,10 @@ class TestSolrApiUtils(unittest.TestCase):
         collection = "test_collection"
         alias = "test_alias"
         configset = "test_configset"
-        SolrApiUtils.remove_and_recreate_collection_from_alias(collection=collection, configset=configset, alias=alias, solr_url="http://sc.example.com", solr_port="443")
+        SolrApiUtils.remove_and_recreate_collection_from_alias(collection=collection, configset=configset, alias=alias, solr_url="http://sc.example.com", solr_port="443", replicationFactor=3)
         mock_remove_collection_from_alias.assert_called_with(collection=collection, alias=alias)
         mock_delete_collection.assert_called_with(collection)
-        mock_create_collection.assert_called_with(collection=collection, configset=configset )
+        mock_create_collection.assert_called_with(collection=collection, configset=configset, replicationFactor=3)
         mock_add_collection_to_alias.assert_called_with(collection=collection, alias=alias)
 
     @patch('tulflow.solr_api_utils.SolrApiUtils.get_from_solr_api')

--- a/tulflow/tasks.py
+++ b/tulflow/tasks.py
@@ -99,7 +99,7 @@ def swap_sc_alias(dag, sc_conn_id, sc_coll_name, sc_configset_name):
 
     return task_instance
 
-def refresh_sc_collection_for_alias(dag, sc_conn, sc_coll_name, sc_alias, configset):
+def refresh_sc_collection_for_alias(dag, sc_conn, sc_coll_name, sc_alias, configset,numShards=None, replicationFactor=None, maxShardsPerNode=None):
     """Removes collection from alias, deletes collection, creates new collection & adds to alias"""
     task_instance = PythonOperator(
         task_id="refresh_sc_collection_for_alias",
@@ -112,6 +112,9 @@ def refresh_sc_collection_for_alias(dag, sc_conn, sc_coll_name, sc_alias, config
             "solr_port": sc_conn.port,
             "solr_auth_user": sc_conn.login or "",
             "solr_auth_pass": sc_conn.password or "",
+            "numShards": numShards,
+            "replicationFactor": replicationFactor,
+            "maxShardsPerNode": maxShardsPerNode
         },
         dag=dag
     )


### PR DESCRIPTION
This PR does 2 things
1) Updates the refresh collection in alias task to allow solrcloud
collection parameters like replicationFactor and numShards to be passed
form the DAG.

2) Updates the function to create a collection in an alias so that it
removes the dummy "*-init" collections used to initially create the
alias.