### PR TITLE
Cache pulling CSV file from s3.

### DIFF
--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -413,7 +413,7 @@ class TestOAIHarvestInteraction(unittest.TestCase):
 
 
     @mock_s3
-    def test_perform_xml_lookup(self, **kwargs):
+    def test_perform_xml_lookup_with_cache(self, **kwargs):
         """Test Calling handling XML Element to String with Deletes."""
         kwargs["access_id"] = "cats"
         kwargs["access_secret"] = "dogs"
@@ -429,7 +429,8 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         conn.put_object(Bucket=kwargs.get("bucket_name"), Key=kwargs.get("lookup_key"), Body=lookup)
         marc_xml = etree.fromstring(marc_single)
         with self.assertLogs() as log:
-            resp_xml = harvest.perform_xml_lookup(marc_xml, **kwargs)
+            parser = harvest.perform_xml_lookup_with_cache()
+            resp_xml = parser(marc_xml, **kwargs)
         self.assertIn("INFO:root:Reading in Record 991000000269703811", log.output)
         self.assertIn("INFO:root:Child XML record found 991000000269703811", log.output)
         self.assertIn(b"<datafield>test</datafield>", etree.tostring(resp_xml))

--- a/tulflow/transform.py
+++ b/tulflow/transform.py
@@ -58,9 +58,9 @@ def prepare_saxon_engine(saxon_jar="saxon.jar", saxon_path="/tmp/saxon/"):
 
     if not os.path.exists(saxon_path + saxon_jar):
         os.mkdir(saxon_path)
-        request_url = "http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/"
+        request_url = "https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/"
         request_url += saxon_version + "/Saxon-HE-" + saxon_version + ".jar"
-        resp = requests.get(request_url, allow_redirects=True)
+        resp = requests.get(request_url, allow_redirects=True, verify=False)
         if hashlib.sha1(resp.content).hexdigest() == saxon_download_sha1:
             open(saxon_path + saxon_jar, "wb").write(resp.content)
             os.chmod(saxon_path + saxon_jar, 0o744)


### PR DESCRIPTION
We only need to do this once vs. every time the parser gets called.

We achieve an in memory cache by returning a closure with cache defined
as an empty map.