### PR TITLE
BL-1125 Use correct oai namespace for updated and deleted files.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     setup_requires=['setuptools>=17.1'],
-    version="0.5.2"
+    version="0.5.3"
 )

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -140,6 +140,13 @@ marc = """
                 <setSpec>blacklight</setSpec>
             </header>
         </record>
+        <record>
+            <header status="deleted">
+                <identifier>oai:alma.01TULI_INST:991000000939703812</identifier>
+                <datestamp>2018-04-02T21:02:12Z</datestamp>
+                <setSpec>blacklight</setSpec>
+            </header>
+        </record>
     </ListRecords>
 </OAI-PMH>
 """
@@ -409,8 +416,10 @@ class TestOAIHarvestInteraction(unittest.TestCase):
             response = harvest.harvest_oai(**kwargs)
             harvest.process_xml(response, harvest.write_log, "test-dir", **kwargs)
         self.assertIn("INFO:root:OAI Records Harvested & Processed: 1", log.output)
-        self.assertIn("INFO:root:OAI Records Harvest & Marked for Deletion: 1", log.output)
-        self.assertIn('INFO:root:<collection dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><ns0:record xmlns:ns0="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" airflow-record-id="oai:alma.01TULI_INST:991000000269703811"><ns0:header><ns0:identifier>oai:alma.01TULI_INST:991000000269703811</ns0:identifier><ns0:datestamp>2019-07-15T15:17:33Z</ns0:datestamp><ns0:setSpec>blacklight</ns0:setSpec><ns0:setSpec>blacklight_qa</ns0:setSpec><ns0:setSpec>rapid_print_books</ns0:setSpec></ns0:header><ns0:metadata><record xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"><leader>01407nam a2200445 4500</leader><controlfield tag="005">20190715090942.0</controlfield><controlfield tag="008">690326s1969 nju b 000 0 eng </controlfield><controlfield tag="001">991000000269703811</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">68020157</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(PPT)b10000276-01tuli_inst</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">DLC</subfield><subfield code="b">eng</subfield><subfield code="c">DLC</subfield><subfield code="d">PPT</subfield></datafield><datafield tag="090" ind1=" " ind2=" "><subfield code="a">HM131.E85</subfield></datafield><datafield tag="100" ind1="1" ind2=" "><subfield code="a">Etzioni, Amitai.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n79089329</subfield></datafield><datafield tag="245" ind1="1" ind2="0"><subfield code="a">Readings on modern organizations.</subfield></datafield></record></ns0:metadata></ns0:record></collection>', log.output)
+        self.assertIn("INFO:root:OAI Records Harvest & Marked for Deletion: 2", log.output)
+        self.assertIn('INFO:root:<oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:ListRecords><oai:record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" airflow-record-id="oai:alma.01TULI_INST:991000000269703811"><oai:header><oai:identifier>oai:alma.01TULI_INST:991000000269703811</oai:identifier><oai:datestamp>2019-07-15T15:17:33Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec><oai:setSpec>blacklight_qa</oai:setSpec><oai:setSpec>rapid_print_books</oai:setSpec></oai:header><oai:metadata><record xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"><leader>01407nam a2200445 4500</leader><controlfield tag="005">20190715090942.0</controlfield><controlfield tag="008">690326s1969 nju b 000 0 eng </controlfield><controlfield tag="001">991000000269703811</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">68020157</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(PPT)b10000276-01tuli_inst</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">DLC</subfield><subfield code="b">eng</subfield><subfield code="c">DLC</subfield><subfield code="d">PPT</subfield></datafield><datafield tag="090" ind1=" " ind2=" "><subfield code="a">HM131.E85</subfield></datafield><datafield tag="100" ind1="1" ind2=" "><subfield code="a">Etzioni, Amitai.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n79089329</subfield></datafield><datafield tag="245" ind1="1" ind2="0"><subfield code="a">Readings on modern organizations.</subfield></datafield></record></oai:metadata></oai:record></oai:ListRecords></oai:OAI-PMH>', log.output)
+        # assert multiple deletions get added as expected
+        self.assertIn('INFO:root:<oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:ListRecords><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703811"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703811</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703812"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703812</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record></oai:ListRecords></oai:OAI-PMH>', log.output)
 
 
     @mock_s3

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -24,7 +24,7 @@ NS = {
     }
 
 lizards = """
-<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+<collection xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-08-30T13:46:14Z</responseDate>
@@ -49,7 +49,7 @@ lizards = """
 """
 
 animals = """
-<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+<collection xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-08-30T13:46:14Z</responseDate>
@@ -88,7 +88,7 @@ animals = """
 """
 
 marc = """
-<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
+<collection xmlns="http://www.openarchives.org/OAI/2.0/"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-11-08T13:43:00Z</responseDate>
@@ -201,7 +201,7 @@ lookup = """child_id,parent_id,parent_xml
 
 listSets = """
 <?xml version="1.0" encoding="UTF-8"?>
-<OAI-PMH
+<collection
     xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
@@ -417,9 +417,9 @@ class TestOAIHarvestInteraction(unittest.TestCase):
             harvest.process_xml(response, harvest.write_log, "test-dir", **kwargs)
         self.assertIn("INFO:root:OAI Records Harvested & Processed: 1", log.output)
         self.assertIn("INFO:root:OAI Records Harvest & Marked for Deletion: 2", log.output)
-        self.assertIn('INFO:root:<oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:ListRecords><oai:record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" airflow-record-id="oai:alma.01TULI_INST:991000000269703811"><oai:header><oai:identifier>oai:alma.01TULI_INST:991000000269703811</oai:identifier><oai:datestamp>2019-07-15T15:17:33Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec><oai:setSpec>blacklight_qa</oai:setSpec><oai:setSpec>rapid_print_books</oai:setSpec></oai:header><oai:metadata><record xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"><leader>01407nam a2200445 4500</leader><controlfield tag="005">20190715090942.0</controlfield><controlfield tag="008">690326s1969 nju b 000 0 eng </controlfield><controlfield tag="001">991000000269703811</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">68020157</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(PPT)b10000276-01tuli_inst</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">DLC</subfield><subfield code="b">eng</subfield><subfield code="c">DLC</subfield><subfield code="d">PPT</subfield></datafield><datafield tag="090" ind1=" " ind2=" "><subfield code="a">HM131.E85</subfield></datafield><datafield tag="100" ind1="1" ind2=" "><subfield code="a">Etzioni, Amitai.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n79089329</subfield></datafield><datafield tag="245" ind1="1" ind2="0"><subfield code="a">Readings on modern organizations.</subfield></datafield></record></oai:metadata></oai:record></oai:ListRecords></oai:OAI-PMH>', log.output)
+        self.assertIn('INFO:root:<oai:collection xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:record xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" airflow-record-id="oai:alma.01TULI_INST:991000000269703811"><oai:header><oai:identifier>oai:alma.01TULI_INST:991000000269703811</oai:identifier><oai:datestamp>2019-07-15T15:17:33Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec><oai:setSpec>blacklight_qa</oai:setSpec><oai:setSpec>rapid_print_books</oai:setSpec></oai:header><oai:metadata><record xmlns="http://www.loc.gov/MARC21/slim" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"><leader>01407nam a2200445 4500</leader><controlfield tag="005">20190715090942.0</controlfield><controlfield tag="008">690326s1969 nju b 000 0 eng </controlfield><controlfield tag="001">991000000269703811</controlfield><datafield tag="010" ind1=" " ind2=" "><subfield code="a">68020157</subfield></datafield><datafield tag="035" ind1=" " ind2=" "><subfield code="a">(PPT)b10000276-01tuli_inst</subfield></datafield><datafield tag="040" ind1=" " ind2=" "><subfield code="a">DLC</subfield><subfield code="b">eng</subfield><subfield code="c">DLC</subfield><subfield code="d">PPT</subfield></datafield><datafield tag="090" ind1=" " ind2=" "><subfield code="a">HM131.E85</subfield></datafield><datafield tag="100" ind1="1" ind2=" "><subfield code="a">Etzioni, Amitai.</subfield><subfield code="0">http://id.loc.gov/authorities/names/n79089329</subfield></datafield><datafield tag="245" ind1="1" ind2="0"><subfield code="a">Readings on modern organizations.</subfield></datafield></record></oai:metadata></oai:record></oai:collection>', log.output)
         # assert multiple deletions get added as expected
-        self.assertIn('INFO:root:<oai:OAI-PMH xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:ListRecords><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703811"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703811</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703812"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703812</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record></oai:ListRecords></oai:OAI-PMH>', log.output)
+        self.assertIn('INFO:root:<oai:collection xmlns:oai="http://www.openarchives.org/OAI/2.0/" dag-id="no-dag-provided" dag-timestamp="no-timestamp-provided"><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703811"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703811</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record><oai:record airflow-record-id="oai:alma.01TULI_INST:991000000939703812"><oai:header status="deleted"><oai:identifier>oai:alma.01TULI_INST:991000000939703812</oai:identifier><oai:datestamp>2018-04-02T21:02:12Z</oai:datestamp><oai:setSpec>blacklight</oai:setSpec></oai:header></oai:record></oai:collection>', log.output)
 
 
     @mock_s3

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -24,7 +24,7 @@ NS = {
     }
 
 lizards = """
-<collection xmlns="http://www.openarchives.org/OAI/2.0/"
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-08-30T13:46:14Z</responseDate>
@@ -49,7 +49,7 @@ lizards = """
 """
 
 animals = """
-<collection xmlns="http://www.openarchives.org/OAI/2.0/"
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-08-30T13:46:14Z</responseDate>
@@ -88,7 +88,7 @@ animals = """
 """
 
 marc = """
-<collection xmlns="http://www.openarchives.org/OAI/2.0/"
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
     <responseDate>2019-11-08T13:43:00Z</responseDate>
@@ -201,7 +201,7 @@ lookup = """child_id,parent_id,parent_xml
 
 listSets = """
 <?xml version="1.0" encoding="UTF-8"?>
-<collection
+<OAI-PMH
     xmlns="http://www.openarchives.org/OAI/2.0/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -102,7 +102,7 @@ class TestDataProcessInteractions(unittest.TestCase):
         self.assertEqual(log.output, logs)
 
     def test_generate_bw_parent_new_field(self):
-        desired_xml = b"""<ns0:datafield xmlns:ns0="http://www.loc.gov/MARC21/slim" ind1=" " ind2=" " tag="ADF"><ns0:subfield code="a">FAKE_PARENT_ID</ns0:subfield></ns0:datafield>"""
+        desired_xml = b"""<marc21:datafield xmlns:marc21="http://www.loc.gov/MARC21/slim" ind1=" " ind2=" " tag="ADF"><marc21:subfield code="a">FAKE_PARENT_ID</marc21:subfield></marc21:datafield>"""
         test_run = process.generate_bw_parent_field("FAKE_PARENT_ID")
         self.assertEqual(etree.tostring(test_run), desired_xml)
 

--- a/tulflow/harvest.py
+++ b/tulflow/harvest.py
@@ -87,6 +87,23 @@ def harvest_oai(**kwargs):
     return data
 
 
+class OaiXml:
+    """oai-pmh xml etree wrapper"""
+    def __init__(self, dag_id, timestamp):
+        etree.register_namespace("oai", "http://www.openarchives.org/OAI/2.0/")
+        etree.register_namespace("marc21", "http://www.loc.gov/MARC21/slim")
+        self.root = etree.Element("{http://www.openarchives.org/OAI/2.0/}OAI-PMH")
+        self.root.attrib["dag-id"] = dag_id
+        self.root.attrib["dag-timestamp"] = timestamp
+        self.list_records = etree.SubElement(self.root, "{http://www.openarchives.org/OAI/2.0/}ListRecords")
+
+    def append(self, record):
+        self.list_records.append(record)
+
+    def tostring(self):
+       return etree.tostring(self.root).decode("utf-8")
+
+
 def process_xml(data, writer, outdir, **kwargs):
     """Process & Write XML data to S3."""
     parser = kwargs.get("parser")
@@ -101,13 +118,10 @@ def process_xml(data, writer, outdir, **kwargs):
         timestamp = "no-timestamp-provided"
     if not records_per_file:
         records_per_file = 1000
+
     count = deleted_count = 0
-    collection = etree.Element("collection")
-    collection.attrib["dag-id"] = run_id
-    collection.attrib["dag-timestamp"] = timestamp
-    deleted_collection = etree.Element("collection")
-    deleted_collection.attrib["dag-id"] = run_id
-    deleted_collection.attrib["dag-timestamp"] = timestamp
+    oai_updates = OaiXml(run_id, timestamp)
+    oai_deletes = OaiXml(run_id, timestamp)
     logging.info("Processing XML")
 
     for record in data:
@@ -117,23 +131,22 @@ def process_xml(data, writer, outdir, **kwargs):
         if parser:
             record = parser(record, **kwargs)
         if record.xpath(".//oai:header[@status='deleted']", namespaces=NS):
-            logging.info("Deleted record %s", record_id)
+            logging.info("Added record %s to deleted xml file(s)", record_id)
             deleted_count += 1
-            deleted_collection.append(record)
+            oai_deletes.append(record)
+
             if deleted_count % int(records_per_file) == 0:
-                string = etree.tostring(deleted_collection).decode("utf-8")
-                writer(string, outdir + "/deleted", **kwargs)
-                deleted_collection = etree.Element("collection")
+                writer(oai_deletes.tostring(), outdir + "/deleted", **kwargs)
+                oai_deletes = OaiXml(run_id, timestamp)
         else:
-            logging.info("Updated record %s", record_id)
+            logging.info("Added record %s to new-updated xml file", record_id)
             count += 1
-            collection.append(record)
+            oai_updates.append(record)
             if count % int(records_per_file) == 0:
-                string = etree.tostring(collection).decode("utf-8")
-                writer(string, outdir + "/new-updated", **kwargs)
-                collection = etree.Element("collection")
-    writer(etree.tostring(collection).decode("utf-8"), outdir + "/new-updated", **kwargs)
-    writer(etree.tostring(deleted_collection).decode("utf-8"), outdir + "/deleted", **kwargs)
+                writer(oai_updates.tostring(), outdir + "/new-updated", **kwargs)
+                oai_updates = OaiXml(run_id, timestamp)
+    writer(oai_updates.tostring(), outdir + "/new-updated", **kwargs)
+    writer(oai_deletes.tostring(), outdir + "/deleted", **kwargs)
     logging.info("OAI Records Harvested & Processed: %s", count)
     logging.info("OAI Records Harvest & Marked for Deletion: %s", deleted_count)
     return {"updated": count, "deleted": deleted_count}

--- a/tulflow/harvest.py
+++ b/tulflow/harvest.py
@@ -92,13 +92,12 @@ class OaiXml:
     def __init__(self, dag_id, timestamp):
         etree.register_namespace("oai", "http://www.openarchives.org/OAI/2.0/")
         etree.register_namespace("marc21", "http://www.loc.gov/MARC21/slim")
-        self.root = etree.Element("{http://www.openarchives.org/OAI/2.0/}OAI-PMH")
+        self.root = etree.Element("{http://www.openarchives.org/OAI/2.0/}collection")
         self.root.attrib["dag-id"] = dag_id
         self.root.attrib["dag-timestamp"] = timestamp
-        self.list_records = etree.SubElement(self.root, "{http://www.openarchives.org/OAI/2.0/}ListRecords")
 
     def append(self, record):
-        self.list_records.append(record)
+        self.root.append(record)
 
     def tostring(self):
        return etree.tostring(self.root).decode("utf-8")

--- a/tulflow/process.py
+++ b/tulflow/process.py
@@ -12,6 +12,10 @@ NS = {
     "marc21": "http://www.loc.gov/MARC21/slim",
     "oai": "http://www.openarchives.org/OAI/2.0/"
     }
+
+etree.register_namespace("marc21", "http://www.loc.gov/MARC21/slim")
+etree.register_namespace("oai", "http://www.openarchives.org/OAI/2.0")
+
 LOGGER = logging.getLogger('tulflow_process')
 PARSER = etree.XMLParser(remove_blank_text=True)
 


### PR DESCRIPTION
Required for tulibraries/cob_index#51

* Fixes issue where multiple namespaces get added when appending records
to oai deleted list.

* Updates xml so that it is correct oai xml format.