### PR TITLE
Fix harvest not retrying on 500 error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setuptools.setup(
     test_suite='nose.collector',
     tests_require=['nose'],
     setup_requires=['setuptools>=17.1'],
-    version="0.6.2"
+    version="0.6.3"
 )

--- a/tulflow/harvest.py
+++ b/tulflow/harvest.py
@@ -82,7 +82,7 @@ def harvest_oai(**kwargs):
     harvest_params = kwargs.get("harvest_params")
     logging.info("Harvesting from %s", oai_endpoint)
     logging.info("Harvesting %s", harvest_params)
-    request = Sickle(oai_endpoint, retry_status_codes=[500,503])
+    request = Sickle(oai_endpoint, retry_status_codes=[500,503], max_retries=3)
     data = request.ListRecords(**harvest_params)
     return data
 


### PR DESCRIPTION
* Sets max_retries to 3, default is 0.
* Updates tulflow version 0.6.3