### PR TITLE
Update import order

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1157,9 +1157,9 @@
         },
         "jsondiff": {
             "hashes": [
-                "sha256:7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21"
+                "sha256:34941bc431d10aa15828afe1cbb644977a114e75eef6cc74fb58951312326303"
             ],
-            "version": "==1.1.2"
+            "version": "==1.2.0"
         },
         "jsonpatch": {
             "hashes": [
@@ -1277,13 +1277,20 @@
             ],
             "version": "==4.0.2"
         },
+        "more-itertools": {
+            "hashes": [
+                "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330",
+                "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"
+            ],
+            "version": "==8.6.0"
+        },
         "moto": {
             "hashes": [
-                "sha256:2b3fa22778504b45715868cad95ad458fdea7227f9005b12e522fc9c2ae0cabc",
-                "sha256:79aeaeed1592a24d3c488840065a3fcb3f4fa7ba40259e112482454c0e48a03a"
+                "sha256:6c686b1f117563391957ce47c2106bc3868783d59d0e004d2446dce875bec07f",
+                "sha256:f51903b6b532f6c887b111b3343f6925b77eef0505a914138d98290cf3526df9"
             ],
             "index": "pypi",
-            "version": "==1.3.14"
+            "version": "==1.3.16"
         },
         "networkx": {
             "hashes": [
@@ -1374,6 +1381,9 @@
             "version": "==2.8.1"
         },
         "python-jose": {
+            "extras": [
+                "cryptography"
+            ],
             "hashes": [
                 "sha256:4e4192402e100b5fb09de5a8ea6bcc39c36ad4526341c123d401e2561720335b",
                 "sha256:67d7dfff599df676b04a996520d9be90d6cdb7e6dd10b4c7cacc0c3e2e92f2be"
@@ -1454,6 +1464,7 @@
                 "sha256:9f73d51c2ef1e68cd7bde0825df29b3c6ec89f4ce24ebca3bf9eaa4a23a284db",
                 "sha256:b388399caeeccdc145f06fd0d2665eeecc545385c60b55c282a15a022215af80"
             ],
+            "markers": "python_version > '3'",
             "version": "==3.1.0"
         },
         "toml": {

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,12 +1,11 @@
 """Tests suite for tulflow harvest (Functions for harvesting OAI in Airflow Tasks)."""
 from datetime import datetime
+from unittest import mock
 import hashlib
 import unittest
+from moto import mock_s3
 import boto3
 from lxml import etree
-from moto import mock_s3
-from unittest import mock
-from unittest.mock import patch
 from airflow.hooks.S3_hook import S3Hook
 from airflow.models import DAG
 from airflow.utils import timezone
@@ -14,8 +13,6 @@ from lxml import etree
 from sickle.iterator import OAIItemIterator
 import httpretty
 from tulflow import harvest
-from types import SimpleNamespace
-from moto import mock_s3
 
 DEFAULT_DATE = timezone.datetime(2019, 8, 16)
 NS = {
@@ -497,8 +494,7 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         kwargs["all_sets"] = True
         kwargs["dag"] = dag
         kwargs["timestamp"] = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        
+
         mock_process.return_value = {"updated": 2, "deleted": 0 }
         response = harvest.oai_to_s3(**kwargs)
         self.assertEqual(response, {"updated": 2, "deleted": 0 })
-

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,9 +1,9 @@
 """Tests suite for tulflow harvest (Functions for harvesting OAI in Airflow Tasks)."""
 import unittest
+from moto import mock_s3
 import boto3
 import httpretty
 from lxml import etree
-from moto import mock_s3
 from tulflow import process
 
 class TestDataProcessInteractions(unittest.TestCase):

--- a/tests/test_solr_api_utils.py
+++ b/tests/test_solr_api_utils.py
@@ -2,9 +2,9 @@
 import json
 from re import compile as re_compile
 import unittest
+from unittest.mock import patch
 import requests_mock
 from tulflow.solr_api_utils import SolrApiUtils
-from unittest.mock import Mock, patch
 
 
 class TestSolrApiUtils(unittest.TestCase):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,7 +1,7 @@
 """Tests suite for tulflow tasks (generic Airflow Tasks as Functions)."""
 import unittest
-import pytest
 from unittest.mock import patch
+import pytest
 from airflow.contrib.operators.slack_webhook_operator import SlackWebhookOperator
 from airflow.operators.http_operator import SimpleHttpOperator
 from airflow.hooks.base_hook import BaseHook

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,10 +1,9 @@
 """Tests suite for tulflow.transform (functions for transforming XML or JSON in Airflow Tasks)."""
 import unittest
+from moto import mock_s3
 import boto3
 from lxml import etree
-from moto import mock_s3
 from tulflow import transform
-import logging
 from mock import patch
 
 class TestXSLTransform(unittest.TestCase):

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,10 +1,9 @@
 """Tests suite for tulflow.validate (functions for validating XML or JSON in Airflow Tasks)."""
 import unittest
+from moto import mock_s3
 import boto3
 from lxml import etree
-from moto import mock_s3
-from tulflow import process, validate
-import logging
+from tulflow import validate
 from mock import patch
 from airflow import AirflowException
 


### PR DESCRIPTION
- The dependabot Moto upgrade is currently failing.  One of the fixes suggested is to make sure that Moto is imported before boto.  When looking at our test files, several of our imports were not in the recommended order.  This updates everything to the correct order and removes unused imports.  All tests are currently passing locally.