### PR TITLE
FLYPIE-255: Do not fail on empty oai harvest.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import setuptools
 from setuptools.command.install import install
 
-VERSION = "0.6.3"
+VERSION = "0.7.0"
 
 with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -369,6 +369,27 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         self.assertIn(b"<setSpec>dpla_test</setSpec>", xml_output)
         self.assertIn(b"<dcterms:title>lizards</dcterms:title>", xml_output)
 
+    @httpretty.activate
+    def test_harvest_oai_no_records(self, **kwargs):
+        """Test Calling OAI-PMH HTTP Endpoint & Returning XML String."""
+        httpretty.register_uri(
+            httpretty.GET,
+            "http://127.0.0.1/combine/oai",
+            body="""
+            <?xml version="1.0" encoding="UTF-8"?><OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd"><responseDate>2021-01-04T19:12:46Z</responseDate><request verb="ListRecords" metadataPrefix="oai_qdc" set="p15860coll2">http://cdm15860.contentdm.oclc.org/oai/oai.php</request><error code="noRecordsMatch">The combination of the values of the from, until, set and metadataPrefix arguments results in an empty list. </error></OAI-PMH>
+            """
+        )
+
+        kwargs["oai_endpoint"] = "http://127.0.0.1/combine/oai"
+        kwargs["harvest_params"] = {
+            "metadataPrefix": "generic",
+            "included_sets": "dpla_test",
+            "from": None,
+            "until": None
+        }
+
+        response = harvest.harvest_oai(**kwargs)
+        self.assertEqual(response, [])
 
     @httpretty.activate
     def test_process_xml_dpla(self, **kwargs):

--- a/tulflow/harvest.py
+++ b/tulflow/harvest.py
@@ -9,6 +9,7 @@ import logging
 import pandas
 from lxml import etree
 from sickle import Sickle
+from sickle.oaiexceptions import NoRecordsMatch
 from tulflow import process
 
 
@@ -83,8 +84,11 @@ def harvest_oai(**kwargs):
     logging.info("Harvesting from %s", oai_endpoint)
     logging.info("Harvesting %s", harvest_params)
     request = Sickle(oai_endpoint, retry_status_codes=[500,503], max_retries=3)
-    data = request.ListRecords(**harvest_params)
-    return data
+    try:
+        return request.ListRecords(**harvest_params)
+    except NoRecordsMatch:
+        logging.info("No records found.")
+        return []
 
 
 class OaiXml:


### PR DESCRIPTION
* Catches empty oai harvest error and returns an empty list instead.

* Updates version of tulflow.