### PR TITLE
Revert "Do not process empty data."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import setuptools
 from setuptools.command.install import install
 
-VERSION = "v0.7.3"
+VERSION = "v0.7.2"
 
 with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -541,24 +541,9 @@ class TestOAIHarvestInteraction(unittest.TestCase):
         actual = harvest.oai_to_s3(**kwargs)
         self.assertEqual(actual, {"updated": 4, "deleted": 0, "sets_with_no_records": []})
 
-    @mock.patch("tulflow.harvest.harvest_oai")
-    @mock.patch("tulflow.harvest.dag_s3_prefix")
-    @mock.patch("tulflow.harvest.process_xml")
-    def test_oai_to_s3_harvest_not_process_empty_data(self, mock_process, mock_prefix, mock_harvest, **kwargs):
-        """Test oai_to_s3 does not process empty data"""
-        dag = DAG(dag_id="test_slacksuccess", start_date=DEFAULT_DATE)
-        kwargs["oai_endpoint"] = "http://test/combine/oai"
-        kwargs["metadataPrefix"] = "blergh"
-        kwargs["included_sets"] = ["set1", "set2"]
-        kwargs["from"] = "from"
-        kwargs["until"] = "until"
-        kwargs["dag"] = dag
-        kwargs["timestamp"] = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
         mock_harvest.return_value = []
         mock_process.return_value = {"updated": 0, "deleted": 0 }
         actual = harvest.oai_to_s3(**kwargs)
-        self.assertFalse(mock_process.called)
         self.assertEqual(actual, {"updated": 0, "deleted": 0, "sets_with_no_records": ["set1", "set2"]})
 
     @mock.patch("tulflow.harvest.harvest_oai")

--- a/tulflow/harvest.py
+++ b/tulflow/harvest.py
@@ -39,8 +39,6 @@ def oai_to_s3(**kwargs):
             data = harvest_oai(**kwargs)
             if data == []:
                 sets_with_no_records.append(oai_set)
-                logging.info("Skipping processing % set because it has no data.", oai_set)
-                continue
             outdir = dag_s3_prefix(dag_id, dag_start_date)
             processed = process_xml(data, dag_write_string_to_s3, outdir, **kwargs)
             all_processed.append(processed)


### PR DESCRIPTION
Reverts tulibraries/tulflow#126

Reverting because it doesn't look like this fixes issue.  Even though from log it looks like script gets upto the count step without error, it still fails.  It would probably require downloading the xml file locally and processing it locally instead of via URL.