### PR TITLE
Always enforce utf-8 encoding.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 import setuptools
 from setuptools.command.install import install
 
-VERSION = "v0.8.0"
+VERSION = "v0.8.1"
 
 with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()

--- a/tulflow/process.py
+++ b/tulflow/process.py
@@ -40,6 +40,7 @@ def add_marc21xml_root_ns(data_in):
     source_xml = etree.fromstring(data_in, parser=PARSER)
     if (not source_xml.attrib.get("xmlns")) and ("{http://www.loc.gov/MARC21/slim}" not in source_xml.tag):
         source_xml.attrib["xmlns"] = "http://www.loc.gov/MARC21/slim"
+    # The reason this is here is to catch encoding errors early.
     source_xml = etree.fromstring(etree.tostring(source_xml, encoding="utf-8"), parser=PARSER)
     return source_xml
 

--- a/tulflow/process.py
+++ b/tulflow/process.py
@@ -40,7 +40,7 @@ def add_marc21xml_root_ns(data_in):
     source_xml = etree.fromstring(data_in, parser=PARSER)
     if (not source_xml.attrib.get("xmlns")) and ("{http://www.loc.gov/MARC21/slim}" not in source_xml.tag):
         source_xml.attrib["xmlns"] = "http://www.loc.gov/MARC21/slim"
-    source_xml = etree.fromstring(etree.tostring(source_xml))
+    source_xml = etree.fromstring(etree.tostring(source_xml, encoding="utf-8"), parser=PARSER)
     return source_xml
 
 
@@ -67,12 +67,12 @@ def get_record_001(record):
 
     if record_ids == [] or record_ids[0].text is None:
         LOGGER.error("Record without an 001 MMS Identifier:")
-        LOGGER.error(str(etree.tostring(record)))
+        LOGGER.error(str(etree.tostring(record, encoding="utf8")))
         return None
 
     if len(record_ids) > 1:
         LOGGER.error("Record with multiple 001 MMS Identifiers:")
-        LOGGER.error(str(etree.tostring(record)))
+        LOGGER.error(str(etree.tostring(record, encoding="utf8")))
         return None
 
     return record_ids[0].text

--- a/tulflow/transform.py
+++ b/tulflow/transform.py
@@ -43,12 +43,12 @@ def transform_s3_xsl(**kwargs):
         for record in s3_xml.iterchildren():
             record_id = record.get("airflow-record-id")
             logging.info("Transforming Record %s", record_id)
-            result_str = subprocess.check_output(["java", "-jar", saxon, "-xsl:" + xsl, "-s:-"], input=etree.tostring(record))
+            result_str = subprocess.check_output(["java", "-jar", saxon, "-xsl:" + xsl, "-s:-"], input=etree.tostring(record, encoding="utf-8"))
             result = etree.fromstring(result_str)
             result.attrib["airflow-record-id"] = record_id
             transformed.append(result)
         filename = s3_key.replace(source_prefix, dest_prefix)
-        transformed_xml = etree.tostring(transformed)
+        transformed_xml = etree.tostring(transformed, encoding="utf-8")
         process.generate_s3_object(transformed_xml, bucket, filename, access_id, access_secret)
 
 


### PR DESCRIPTION
We've been running into a lot of encoding/decoding issues with full
reindex dag.

The xml for indexing files are very big one line files, so I think always
enforcing utf-8 encoding will help prevent this parsing errors with
lxml.