### PR TITLE
Replace raw.github.com with raw.githubusercontent.com

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -111,7 +111,7 @@ class TestDataProcessInteractions(unittest.TestCase):
         """Test getting existing file from GitHub."""
         httpretty.register_uri(
             httpretty.GET,
-            "https://raw.github.com/tulibraries/aggregator_mdx/main/transforms/temple.xsl",
+            "https://raw.githubusercontent.com/tulibraries/aggregator_mdx/main/transforms/temple.xsl",
             body=open("tests/fixtures/temple.xsl").read()
         )
         repository = "tulibraries/aggregator_mdx"
@@ -125,7 +125,7 @@ class TestDataProcessInteractions(unittest.TestCase):
         """Test getting missing file from GitHub & return appropriate error."""
         httpretty.register_uri(
             httpretty.GET,
-            "https://raw.github.com/tulibraries/aggregator_mdx/main/transforms/temple-fake.xsl",
+            "https://raw.githubusercontent.com/tulibraries/aggregator_mdx/main/transforms/temple-fake.xsl",
             status=404
         )
         repository = "tulibraries/aggregator_mdx"
@@ -135,7 +135,7 @@ class TestDataProcessInteractions(unittest.TestCase):
             with self.assertRaises(SystemExit) as pytest_wrapped_e:
                 process.get_github_content(repository, filename)
         self.assertEqual(pytest_wrapped_e.exception.code, 1)
-        self.assertIn("ERROR:root:404 Client Error: Not Found for url: https://raw.github.com/tulibraries/aggregator_mdx/main/transforms/temple-fake.xsl", log.output)
+        self.assertIn("ERROR:root:404 Client Error: Not Found for url: https://raw.githubusercontent.com/tulibraries/aggregator_mdx/main/transforms/temple-fake.xsl", log.output)
 
 class TestS3ProcessInteractions(unittest.TestCase):
     """Test Class for S3 data processing functions."""

--- a/tulflow/process.py
+++ b/tulflow/process.py
@@ -92,7 +92,7 @@ def generate_bw_parent_field(parent_id):
 
 def get_github_content(repository, filename, branch="main"):
     """Get the contents of GitHub file."""
-    raw_url = "https://raw.github.com/{repo}/{branch}/{filename}".format(
+    raw_url = "https://raw.githubusercontent.com/{repo}/{branch}/{filename}".format(
         repo=repository,
         branch=branch,
         filename=filename

--- a/tulflow/transform.py
+++ b/tulflow/transform.py
@@ -30,7 +30,7 @@ def transform_s3_xsl(**kwargs):
     transformed = etree.Element("collection")
     transformed.attrib["dag-id"] = run_id
     transformed.attrib["dag-timestamp"] = kwargs.get("timestamp", "no-timestamp-provided")
-    xsl = "https://raw.github.com/{repo}/{branch}/{filename}".format(
+    xsl = "https://raw.githubusercontent.com/{repo}/{branch}/{filename}".format(
         repo=kwargs.get("xsl_repository", "tulibraries/aggregator_mdx"),
         branch=kwargs.get("xsl_branch", "main"),
         filename=kwargs.get("xsl_filename")


### PR DESCRIPTION
- Addresses 503 error when DAGs run
- raw.github.com has no tls certificate
- All content is in raw.githubusercontent.com which has the tls certificate.